### PR TITLE
Checkout: Show branch and commit in the output

### DIFF
--- a/libcheckout
+++ b/libcheckout
@@ -9,7 +9,8 @@ function checkout() {
     return 1
   fi
 
-  git clone --branch $SEMAPHORE_GIT_BRANCH $SEMAPHORE_GIT_URL $SEMAPHORE_GIT_DIR
+  git clone $SEMAPHORE_GIT_URL $SEMAPHORE_GIT_DIR
   cd $SEMAPHORE_GIT_DIR
-  git reset -q --hard $SEMAPHORE_GIT_SHA
+  git checkout $SEMAPHORE_GIT_BRANCH
+  git reset --hard $SEMAPHORE_GIT_SHA
 }


### PR DESCRIPTION
Previously the checkout have generated the following example output:
```
Cloning into 'guard'...
remote: Counting objects: 963, done.
remote: Compressing objects: 100% (156/156), done.
remote: Total 963 (delta 87), reused 140 (delta 48), pack-reused 747
Receiving objects: 100% (963/963), 149.42 KiB | 0 bytes/s, done.
Resolving deltas: 100% (480/480), done.
Checking connectivity... done.
```

Without showing the branch nor version of the code being set.

By using these commands the output would be the following:
```
Cloning into 'guard'...
remote: Counting objects: 963, done.
remote: Compressing objects: 100% (156/156), done.
remote: Total 963 (delta 87), reused 140 (delta 48), pack-reused 747
Receiving objects: 100% (963/963), 149.42 KiB | 0 bytes/s, done.
Resolving deltas: 100% (480/480), done.
Checking connectivity... done.
Branch bmarkons-patch-1 set up to track remote branch bmarkons-patch-1 from origin.
Switched to a new branch 'bmarkons-patch-1'                   <--
HEAD is now at 43ec9b7 Move semaphore.yml to /semaphore dir   <--
```

The output is more transparent showing the exact revision being checked out.