### PR TITLE
Lr/fix missing rev

### DIFF
--- a/libcheckout
+++ b/libcheckout
@@ -64,7 +64,7 @@ function checkout::fetch() {
   else
     git checkout -b $SEMAPHORE_GIT_BRANCH -t $branch_origin;
   fi
-
+  checkout::checkrev
   git reset --hard $SEMAPHORE_GIT_SHA
 }
 
@@ -72,6 +72,7 @@ function checkout::clone() {
   git clone $SEMAPHORE_GIT_URL $SEMAPHORE_GIT_DIR
   cd $SEMAPHORE_GIT_DIR
   git checkout $SEMAPHORE_GIT_BRANCH
+  checkout::checkrev
   git reset --hard $SEMAPHORE_GIT_SHA
 }
 
@@ -118,6 +119,14 @@ function checkout::cleanupcache {
 
 }
 
+function checkout::checkrev {
+  git rev-list HEAD..$SEMAPHORE_GIT_SHA 2>/dev/null
+  if [ $? -ne 0 ]; then
+    echo "Rev: ${SEMAPHORE_GIT_SHA} not found"
+    exit 1
+  fi
+}
+
 function checkout::shallow() {
   if [ -z ${SEMAPHORE_GIT_DEPTH} ]; then
     SEMAPHORE_GIT_DEPTH=50
@@ -128,6 +137,7 @@ function checkout::shallow() {
     echo "Branch not found performing full clone"
     git clone $SEMAPHORE_GIT_URL $SEMAPHORE_GIT_DIR
     cd $SEMAPHORE_GIT_DIR
+    checkout::checkrev
     git reset --hard $SEMAPHORE_GIT_SHA 2>/dev/null
   else
     cd $SEMAPHORE_GIT_DIR
@@ -135,6 +145,7 @@ function checkout::shallow() {
     if [ $? -ne 0 ]; then
       "SHA: $SEMAPHORE_GIT_SHA not found performing full clone"
       git fetch --unshallow
+      checkout::checkrev
       git reset --hard $SEMAPHORE_GIT_SHA
     fi
   fi

--- a/libcheckout
+++ b/libcheckout
@@ -122,7 +122,7 @@ function checkout::cleanupcache {
 function checkout::checkrevision {
   git rev-list HEAD..$SEMAPHORE_GIT_SHA 2>/dev/null
   if [ $? -ne 0 ]; then
-    echo "Rev: ${SEMAPHORE_GIT_SHA} not found"
+    echo "Revision: ${SEMAPHORE_GIT_SHA} not found"
     exit 1
   fi
 }

--- a/libcheckout
+++ b/libcheckout
@@ -64,7 +64,7 @@ function checkout::fetch() {
   else
     git checkout -b $SEMAPHORE_GIT_BRANCH -t $branch_origin;
   fi
-  checkout::checkrev
+  checkout::checkrevision
   git reset --hard $SEMAPHORE_GIT_SHA
 }
 
@@ -72,7 +72,7 @@ function checkout::clone() {
   git clone $SEMAPHORE_GIT_URL $SEMAPHORE_GIT_DIR
   cd $SEMAPHORE_GIT_DIR
   git checkout $SEMAPHORE_GIT_BRANCH
-  checkout::checkrev
+  checkout::checkrevision
   git reset --hard $SEMAPHORE_GIT_SHA
 }
 
@@ -119,7 +119,7 @@ function checkout::cleanupcache {
 
 }
 
-function checkout::checkrev {
+function checkout::checkrevision {
   git rev-list HEAD..$SEMAPHORE_GIT_SHA 2>/dev/null
   if [ $? -ne 0 ]; then
     echo "Rev: ${SEMAPHORE_GIT_SHA} not found"
@@ -137,7 +137,7 @@ function checkout::shallow() {
     echo "Branch not found performing full clone"
     git clone $SEMAPHORE_GIT_URL $SEMAPHORE_GIT_DIR
     cd $SEMAPHORE_GIT_DIR
-    checkout::checkrev
+    checkout::checkrevision
     git reset --hard $SEMAPHORE_GIT_SHA 2>/dev/null
   else
     cd $SEMAPHORE_GIT_DIR
@@ -145,7 +145,7 @@ function checkout::shallow() {
     if [ $? -ne 0 ]; then
       "SHA: $SEMAPHORE_GIT_SHA not found performing full clone"
       git fetch --unshallow
-      checkout::checkrev
+      checkout::checkrevision
       git reset --hard $SEMAPHORE_GIT_SHA
     fi
   fi

--- a/tests/libcheckout.bats
+++ b/tests/libcheckout.bats
@@ -133,5 +133,5 @@ teardown() {
 
   run checkout --use-cache
   assert_failure
-  assert_output --partial "Rev: $SEMAPHORE_GIT_SHA not found"
+  assert_output --partial "Revision: $SEMAPHORE_GIT_SHA not found"
 }

--- a/tests/libcheckout.bats
+++ b/tests/libcheckout.bats
@@ -124,3 +124,14 @@ teardown() {
 
   cache clear
 }
+
+@test "libcheckout - Checkout and use-cache nonexisting SHA" {
+  export SEMAPHORE_GIT_SHA=1234567
+  export SEMAPHORE_GIT_BRANCH=master
+  cd ~
+  rm -rf $SEMAPHORE_GIT_DIR
+
+  run checkout --use-cache
+  assert_failure
+  assert_output --partial "Rev: $SEMAPHORE_GIT_SHA not found"
+}


### PR DESCRIPTION
Fix the behaviour where `checkout --use-cache` does not fail if the git revision does not exist