### PR TITLE
Skip SSH key check

### DIFF
--- a/cache
+++ b/cache
@@ -695,7 +695,7 @@ cache::log() {
 
 cache::main() {
   cache::check_lftp
-  cache::check_ssh_key
+  # cache::check_ssh_key
   cache::check_env
 
   case "$1" in


### PR DESCRIPTION
This PR is opened to avoid confusion caused by differences in evaluating $HOME variable in Docker based jobs. Job is able to communicate with cache server, key is present in in job environment, but warning log is printed. 

![image](https://user-images.githubusercontent.com/10695735/59351426-0cd46d80-8d27-11e9-98e7-a2f96b424db4.png)
