### PR TITLE
Caching that recognizes the project structure

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -144,7 +144,8 @@ blocks:
           - cd .toolbox
           - git submodule init && git submodule update
           - ./tests/support/bats-core/install.sh /usr/local
-          - bats tests
+          - bats tests/cache.bats
+          - bats tests/libcheckout.bats
 
   - name: Run tests in Docker container
     task:
@@ -166,7 +167,8 @@ blocks:
           - cd .toolbox
           - git submodule init && git submodule update
           - ./tests/support/bats-core/install.sh /usr/local
-          - bats tests
+          - bats tests/cache.bats
+          - bats tests/libcheckout.bats
 
   - name: Run tests in MacOS env
     task:

--- a/cache
+++ b/cache
@@ -72,7 +72,7 @@ cache::autostore() {
               SEMAPHORE_CACHE_KEY=$(cache::normalize_string gems-$SEMAPHORE_GIT_BRANCH-$(checksum Gemfile.lock))
               cache::lftp_put
             else
-              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to sotre in cache."
+              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to store in cache."
             fi
             ;;
           "package-lock.json")
@@ -83,7 +83,7 @@ cache::autostore() {
               SEMAPHORE_CACHE_KEY=$(cache::normalize_string node-mdoules-$SEMAPHORE_GIT_BRANCH-$(checksum package-lock.json))
               cache::lftp_put
             else
-              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to sotre in cache."
+              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to store in cache."
             fi
             ;;
           "yarn.lock")
@@ -94,7 +94,7 @@ cache::autostore() {
               SEMAPHORE_CACHE_KEY=$(cache::normalize_string yarn-cache-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock))
               cache::lftp_put
             else
-              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to sotre in cache."
+              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to store in cache."
             fi
             SEMAPHORE_LOCAL_CACHE_PATHS="node_modules"
             cache::log "* Using default cache path '$SEMAPHORE_LOCAL_CACHE_PATHS'."
@@ -102,7 +102,7 @@ cache::autostore() {
               SEMAPHORE_CACHE_KEY=$(cache::normalize_string node-mdoules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock))
               cache::lftp_put
             else
-              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to sotre in cache."
+              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to store in cache."
             fi
             ;;
           "mix.lock")
@@ -113,7 +113,7 @@ cache::autostore() {
               SEMAPHORE_CACHE_KEY=$(cache::normalize_string mix-deps-$SEMAPHORE_GIT_BRANCH-$(checksum mix.lock))
               cache::lftp_put
             else
-              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to sotre in cache."
+              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to store in cache."
             fi
             SEMAPHORE_LOCAL_CACHE_PATHS="_build"
             cache::log "* Using default cache path '$SEMAPHORE_LOCAL_CACHE_PATHS'."
@@ -121,7 +121,7 @@ cache::autostore() {
               SEMAPHORE_CACHE_KEY=$(cache::normalize_string mix-build-$SEMAPHORE_GIT_BRANCH-$(checksum mix.lock))
               cache::lftp_put
             else
-              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to sotre in cache."
+              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to store in cache."
             fi
             ;;
           "requirements.txt")
@@ -132,7 +132,7 @@ cache::autostore() {
               SEMAPHORE_CACHE_KEY=$(cache::normalize_string requirements-$SEMAPHORE_GIT_BRANCH-$(checksum requirements.txt))
               cache::lftp_put
             else
-              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to sotre in cache."
+              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to store in cache."
             fi
             ;;
           "composer.lock")
@@ -143,7 +143,18 @@ cache::autostore() {
               SEMAPHORE_CACHE_KEY=$(cache::normalize_string composer-$SEMAPHORE_GIT_BRANCH-$(checksum composer.lock))
               cache::lftp_put
             else
-              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to sotre in cache."
+              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to store in cache."
+            fi
+            ;;
+          "pom.xml")
+            cache::log "* Detected $lockfile."
+            SEMAPHORE_LOCAL_CACHE_PATHS=".m2"
+            cache::log "* Using default cache path '$SEMAPHORE_LOCAL_CACHE_PATHS'."
+            if [[ -d $SEMAPHORE_LOCAL_CACHE_PATHS ]]; then
+              SEMAPHORE_CACHE_KEY=$(cache::normalize_string maven-$SEMAPHORE_GIT_BRANCH-$(checksum pom.xml))
+              cache::lftp_put
+            else
+              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to store in cache."
             fi
             ;;
           *)
@@ -200,6 +211,12 @@ cache::autorestore() {
             SEMAPHORE_LOCAL_CACHE_PATHS="vendor"
             cache::restore composer-$SEMAPHORE_GIT_BRANCH-$(checksum composer.lock),composer-$SEMAPHORE_GIT_BRANCH,composers-master
             ;;
+          "pom.xml")
+            cache::log "* Detected $lockfile."
+            cache::log "* Fetching 'vendor' directory with cache keys 'cache restore maven-$SEMAPHORE_GIT_BRANCH-$(checksum pom.xml),maven-$SEMAPHORE_GIT_BRANCH,maven-master'."
+            SEMAPHORE_LOCAL_CACHE_PATHS=".m2"
+            cache::restore maven-$SEMAPHORE_GIT_BRANCH-$(checksum pom.xml),maven-$SEMAPHORE_GIT_BRANCH,maven-master
+            ;;
           *)
             cache::log "* Nothing to fetch from cache";;
         esac
@@ -220,7 +237,13 @@ cache::autorestore() {
 cache::store() {
   local usage
 
-  usage='Usage: \n\t cache store [key] [local-path]\nExample: \n\t cache store bundle-$SEMAPHORE_GIT_BRANCH-$(checksum Gemfile.lock) vendor/bundle\n'
+  usage='
+Usage:
+      cache store (lookup cachable elements in the project and cache them e.g vendor/bundle)
+      cache store [key] [local-path]
+Example:
+      cache store bundle-$SEMAPHORE_GIT_BRANCH-$(checksum Gemfile.lock) vendor/bundle
+'
 
   if [[ $# -eq 0 ]]; then
     cache::autostore
@@ -329,7 +352,15 @@ cache::restore() {
   local usage
   local semaphore_cache_keys
 
-  usage='Usage: \n\tcache restore [key,key_1,key_2]\nExample: \n\tcache store bundle-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_GIT_SHA\nFallback example:\n\tcache restore bundle-$SEMAPHORE_GIT_BRANCH-$(checksum Gemfile.lock),bundle-$SEMAPHORE_GIT_BRANCH\n'
+  usage='
+Usage:
+    cache restore (lookup cachable elements and try to fetch them from cache)
+    cache restore [key,key_1,key_2]
+Example:
+    cache store bundle-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_GIT_SHA
+Fallback example:
+    cache restore bundle-$SEMAPHORE_GIT_BRANCH-$(checksum Gemfile.lock),bundle-$SEMAPHORE_GIT_BRANCH
+'
 
   if [[ $# -eq 0 ]]; then
     cache::autorestore

--- a/cache
+++ b/cache
@@ -60,9 +60,9 @@ cache::current_timestamp_in_milis() {
 
 cache::autostore() {
 
+  cache::log "==> Detecting project structure and storing into cache."
   for lockfile in ${LOCKFILES[@]}; do
     if [[ -f $lockfile ]]; then
-        cache::log "==> Detecting project structure and storing into cache."
         case $lockfile in
           "Gemfile.lock")
             cache::log "* Detected $lockfile."
@@ -166,9 +166,9 @@ cache::autostore() {
 
 cache::autorestore() {
 
+  cache::log "==> Detecting project structure and fetching cache."
   for lockfile in ${LOCKFILES[@]}; do
     if [[ -f $lockfile ]]; then
-        cache::log "==> Detecting project structure and fetching cache."
         case $lockfile in
           "Gemfile.lock")
             cache::log "* Detected $lockfile."
@@ -365,6 +365,7 @@ Fallback example:
   if [[ $# -eq 0 ]]; then
     cache::autorestore
   elif [[ $# -ne 1 ]]; then
+    cache::log "${usage}"
     cache::err "Incorrect number of arguments!"
   else
     semaphore_cache_keys=$1

--- a/cache
+++ b/cache
@@ -22,7 +22,7 @@ E_FLAE=0 # file already exists
 DATE_FORMAT='%H:%M %d/%m/%Y'
 
 # Lockfiles to lookup for autostore and autoresotre
-LOCKFILES=('Gemfile.lock' 'package-lock.json' 'yarn.lock' 'mix.lock' 'requirements.txt')
+LOCKFILES=('Gemfile.lock' 'package-lock.json' 'yarn.lock' 'mix.lock' 'requirements.txt' 'composer.lock')
 
 cache::verbose() {
   VERBOSE_LOG=0
@@ -135,6 +135,17 @@ cache::autostore() {
               cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to sotre in cache."
             fi
             ;;
+          "composer.lock")
+            cache::log "* Detected $lockfile."
+            SEMAPHORE_LOCAL_CACHE_PATHS="vendor"
+            cache::log "* Using default cache path '$SEMAPHORE_LOCAL_CACHE_PATHS'."
+            if [[ -d $SEMAPHORE_LOCAL_CACHE_PATHS ]]; then
+              SEMAPHORE_CACHE_KEY=$(cache::normalize_string composer-$SEMAPHORE_GIT_BRANCH-$(checksum composer.lock))
+              cache::lftp_put
+            else
+              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to sotre in cache."
+            fi
+            ;;
           *)
             cache::log "* Nothing to sotre in Cache";;
         esac
@@ -182,6 +193,12 @@ cache::autorestore() {
             cache::log "* Fetching '.pip_cache' directory with cache keys 'requirements-$SEMAPHORE_GIT_BRANCH-$(checksum requirements.txt),requirements-$SEMAPHORE_GIT_BRANCH-,requirements-master-'."
             SEMAPHORE_LOCAL_CACHE_PATHS="vendor/bundle"
             cache::restore requirements-$SEMAPHORE_GIT_BRANCH-$(checksum requirements.txt),requirements-$SEMAPHORE_GIT_BRANCH,requirements-master
+            ;;
+          "composer.lock")
+            cache::log "* Detected $lockfile."
+            cache::log "* Fetching 'vendor' directory with cache keys 'composer-$SEMAPHORE_GIT_BRANCH-$(checksum composer.lock),composer-$SEMAPHORE_GIT_BRANCH-,composer-master-'."
+            SEMAPHORE_LOCAL_CACHE_PATHS="vendor"
+            cache::restore composer-$SEMAPHORE_GIT_BRANCH-$(checksum composer.lock),composer-$SEMAPHORE_GIT_BRANCH,composers-master
             ;;
           *)
             cache::log "* Nothing to fetch from cache";;

--- a/cache
+++ b/cache
@@ -21,6 +21,9 @@ E_FLAE=0 # file already exists
 # Misc
 DATE_FORMAT='%H:%M %d/%m/%Y'
 
+# Lockfiles to lookup for autostore and autoresotre
+LOCKFILES=('Gemfile.lock' 'package-lock.json' 'yarn.lock' 'mix.lock' 'requirements.txt')
+
 cache::verbose() {
   VERBOSE_LOG=0
 }
@@ -55,6 +58,138 @@ cache::current_timestamp_in_milis() {
   esac
 }
 
+cache::autostore() {
+
+  for lockfile in ${LOCKFILES[@]}; do
+    if [[ -f $lockfile ]]; then
+        cache::log "==> Detecting project structure and storing into cache."
+        case $lockfile in
+          "Gemfile.lock")
+            cache::log "* Detected $lockfile."
+            SEMAPHORE_LOCAL_CACHE_PATHS="vendor/bundle"
+            cache::log "* Using default cache path '$SEMAPHORE_LOCAL_CACHE_PATHS'."
+            if [[ -d $SEMAPHORE_LOCAL_CACHE_PATHS ]]; then
+              SEMAPHORE_CACHE_KEY=$(cache::normalize_string gems-$SEMAPHORE_GIT_BRANCH-$(checksum Gemfile.lock))
+              cache::lftp_put
+            else
+              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to sotre in cache."
+            fi
+            ;;
+          "package-lock.json")
+            cache::log "* Detected $lockfile."
+            SEMAPHORE_LOCAL_CACHE_PATHS="node_modules"
+            cache::log "* Using default cache path '$SEMAPHORE_LOCAL_CACHE_PATHS'."
+            if [[ -d $SEMAPHORE_LOCAL_CACHE_PATHS ]]; then
+              SEMAPHORE_CACHE_KEY=$(cache::normalize_string node-mdoules-$SEMAPHORE_GIT_BRANCH-$(checksum package-lock.json))
+              cache::lftp_put
+            else
+              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to sotre in cache."
+            fi
+            ;;
+          "yarn.lock")
+            cache::log "* Detected $lockfile."
+            SEMAPHORE_LOCAL_CACHE_PATHS="$HOME/.cache/yarn"
+            cache::log "* Using default cache path '$SEMAPHORE_LOCAL_CACHE_PATHS'."
+            if [[ -d $SEMAPHORE_LOCAL_CACHE_PATHS ]]; then
+              SEMAPHORE_CACHE_KEY=$(cache::normalize_string yarn-cache-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock))
+              cache::lftp_put
+            else
+              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to sotre in cache."
+            fi
+            SEMAPHORE_LOCAL_CACHE_PATHS="node_modules"
+            cache::log "* Using default cache path '$SEMAPHORE_LOCAL_CACHE_PATHS'."
+            if [[ -d $SEMAPHORE_LOCAL_CACHE_PATHS ]]; then
+              SEMAPHORE_CACHE_KEY=$(cache::normalize_string node-mdoules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock))
+              cache::lftp_put
+            else
+              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to sotre in cache."
+            fi
+            ;;
+          "mix.lock")
+            cache::log "* Detected $lockfile."
+            SEMAPHORE_LOCAL_CACHE_PATHS="deps"
+            cache::log "* Using default cache path '$SEMAPHORE_LOCAL_CACHE_PATHS'."
+            if [[ -d $SEMAPHORE_LOCAL_CACHE_PATHS ]]; then
+              SEMAPHORE_CACHE_KEY=$(cache::normalize_string mix-deps-$SEMAPHORE_GIT_BRANCH-$(checksum mix.lock))
+              cache::lftp_put
+            else
+              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to sotre in cache."
+            fi
+            SEMAPHORE_LOCAL_CACHE_PATHS="_build"
+            cache::log "* Using default cache path '$SEMAPHORE_LOCAL_CACHE_PATHS'."
+            if [[ -d $SEMAPHORE_LOCAL_CACHE_PATHS ]]; then
+              SEMAPHORE_CACHE_KEY=$(cache::normalize_string mix-build-$SEMAPHORE_GIT_BRANCH-$(checksum mix.lock))
+              cache::lftp_put
+            else
+              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to sotre in cache."
+            fi
+            ;;
+          "requirements.txt")
+            cache::log "* Detected $lockfile."
+            SEMAPHORE_LOCAL_CACHE_PATHS=".pip_cache"
+            cache::log "* Using default cache path '$SEMAPHORE_LOCAL_CACHE_PATHS'."
+            if [[ -d $SEMAPHORE_LOCAL_CACHE_PATHS ]]; then
+              SEMAPHORE_CACHE_KEY=$(cache::normalize_string requirements-$SEMAPHORE_GIT_BRANCH-$(checksum requirements.txt))
+              cache::lftp_put
+            else
+              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to sotre in cache."
+            fi
+            ;;
+          *)
+            cache::log "* Nothing to sotre in Cache";;
+        esac
+    fi
+  done
+}
+
+cache::autorestore() {
+
+  for lockfile in ${LOCKFILES[@]}; do
+    if [[ -f $lockfile ]]; then
+        cache::log "==> Detecting project structure and fetching cache."
+        case $lockfile in
+          "Gemfile.lock")
+            cache::log "* Detected $lockfile."
+            cache::log "* Fetching 'vendor/bundle' directory with cache keys 'gems-$SEMAPHORE_GIT_BRANCH-$(checksum Gemfile.lock),gems-$SEMAPHORE_GIT_BRANCH-,gems-master-'."
+            SEMAPHORE_LOCAL_CACHE_PATHS="vendor/bundle"
+            cache::restore gems-${SEMAPHORE_GIT_BRANCH}-$(checksum Gemfile.lock),gems-${SEMAPHORE_GIT_BRANCH},gems-master
+            ;;
+          "package-lock.json")
+            cache::log "* Detected $lockfile."
+            cache::log "* Fetching 'node_modules' directory with cache keys 'node-mdoules-$SEMAPHORE_GIT_BRANCH-$(checksum package-lock.json),node-mdoules-$SEMAPHORE_GIT_BRANCH-,node-mdoules-master-'."
+            SEMAPHORE_LOCAL_CACHE_PATHS="node_modules"
+            cache::restore node-mdoules-${SEMAPHORE_GIT_BRANCH}-$(checksum package-lock.json),node-mdoules-${SEMAPHORE_GIT_BRANCH}-,node-mdoules-master-
+            ;;
+          "yarn.lock")
+            cache::log "* Detected $lockfile."
+            cache::log "* Fetching 'semaphore/.cache/yarn' directory with cache keys 'yarn-cache-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock),yarn-cache-$SEMAPHORE_GIT_BRANCH-,yarn-cache-master-'."
+            SEMAPHORE_LOCAL_CACHE_PATHS="$HOME/.cache/yarn"
+            cache::restore yarn-cache-${SEMAPHORE_GIT_BRANCH}-$(checksum yarn.lock),yarn-cache-${SEMAPHORE_GIT_BRANCH}-,yarn-cache-master-
+            mv home/semaphore/.cache/yarn $HOME/.cache/
+            cache::log "* Fetching 'node_modules' directory with cache keys 'node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum yarn.lock),node-modules-$SEMAPHORE_GIT_BRANCH-,node-modules-master-'."
+            SEMAPHORE_LOCAL_CACHE_PATHS="node_modules"
+            cache::restore node-mdoules-${SEMAPHORE_GIT_BRANCH}-$(checksum yarn.lock),node-mdoules-${SEMAPHORE_GIT_BRANCH}-,node-mdoules-master-
+            ;;
+          "mix.lock")
+            cache::log "* Detected $lockfile."
+            cache::log "* Fetching 'deps' directory with cache keys mix-deps-$SEMAPHORE_GIT_BRANCH-$(checksum mix.lock),mix-deps-$SEMAPHORE_GIT_BRANCH,mix-deps-master"
+            cache restore mix-deps-$SEMAPHORE_GIT_BRANCH-$(checksum mix.lock),mix-deps-$SEMAPHORE_GIT_BRANCH,mix-deps-master
+            cache::log "* Fetching '_build' directory with cache keys mix-build-$SEMAPHORE_GIT_BRANCH-$(checksum mix.lock),mix-build-$SEMAPHORE_GIT_BRANCH,mix-build-master"
+            cache restore mix-build-$SEMAPHORE_GIT_BRANCH-$(checksum mix.lock),mix-build-$SEMAPHORE_GIT_BRANCH,mix-build-master
+            ;;
+          "requirements.txt")
+            cache::log "* Detected $lockfile."
+            cache::log "* Fetching '.pip_cache' directory with cache keys 'requirements-$SEMAPHORE_GIT_BRANCH-$(checksum requirements.txt),requirements-$SEMAPHORE_GIT_BRANCH-,requirements-master-'."
+            SEMAPHORE_LOCAL_CACHE_PATHS="vendor/bundle"
+            cache::restore requirements-$SEMAPHORE_GIT_BRANCH-$(checksum requirements.txt),requirements-$SEMAPHORE_GIT_BRANCH,requirements-master
+            ;;
+          *)
+            cache::log "* Nothing to fetch from cache";;
+        esac
+    fi
+  done
+}
+
 ################################################################################
 # Send the files identified by the key, to the cache repository using LFTP
 # Globals:
@@ -71,8 +206,9 @@ cache::store() {
   usage='Usage: \n\t cache store [key] [local-path]\nExample: \n\t cache store bundle-$SEMAPHORE_GIT_BRANCH-$(checksum Gemfile.lock) vendor/bundle\n'
 
   if [[ $# -eq 0 ]]; then
-    cache::log "${usage}"
+    cache::autostore
   elif [[ $# -ne 2 ]]; then
+    cache::log "${usage}"
     cache::err "Incorrect number of arguments!"
   else
     SEMAPHORE_LOCAL_CACHE_PATHS=$2
@@ -179,7 +315,7 @@ cache::restore() {
   usage='Usage: \n\tcache restore [key,key_1,key_2]\nExample: \n\tcache store bundle-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_GIT_SHA\nFallback example:\n\tcache restore bundle-$SEMAPHORE_GIT_BRANCH-$(checksum Gemfile.lock),bundle-$SEMAPHORE_GIT_BRANCH\n'
 
   if [[ $# -eq 0 ]]; then
-    cache::log "${usage}"
+    cache::autorestore
   elif [[ $# -ne 1 ]]; then
     cache::err "Incorrect number of arguments!"
   else

--- a/tests/autocache.bats
+++ b/tests/autocache.bats
@@ -1,0 +1,134 @@
+#!/usr/bin/env bats
+
+load "support/bats-support/load"
+load "support/bats-assert/load"
+
+teardown() {
+  rm -rf semaphore-demo-*
+}
+
+
+################################################################################
+# cache autostore/autorestore
+################################################################################
+
+@test "cache - autostore/autorestore [bundle]" {
+
+  git clone git@github.com:semaphoreci-demos/semaphore-demo-ruby-rails.git
+  cd semaphore-demo-ruby-rails
+  bundle install --path vendor/bundle > /dev/null
+
+  run cache store
+
+  assert_success
+  assert_output --partial "* Detected Gemfile.lock."
+  assert_output --partial "Upload complete."
+
+  rm -rf vendor/bundle
+
+  run cache restore
+  assert_success
+  assert_output --partial  "* Fetching 'vendor/bundle' directory with cache keys"
+  assert_output --partial "Restored: vendor/bundle/"
+
+  run cache delete gems-$SEMAPHORE_GIT_BRANCH-$(checksum Gemfile.lock)
+  cd ../
+  rm -rf semaphore-demo-ruby-rails
+}
+
+@test "cache - autostore/autorestore [pip]" {
+
+  git clone git@github.com:semaphoreci-demos/semaphore-demo-python-django.git
+  cd semaphore-demo-python-django
+  sudo pip install -r requirements.txt --cache-dir .pip_cache > /dev/null
+
+  run cache store
+
+  assert_success
+  assert_output --partial "* Detected requirements.txt"
+  assert_output --partial "Upload complete."
+
+  sudo rm -rf .pip_cache
+
+  run cache restore
+  assert_success
+  assert_output --partial "* Fetching '.pip_cache' directory with cache keys"
+  assert_output --partial "Restored: .pip_cache/"
+
+  run cache delete requirements-$SEMAPHORE_GIT_BRANCH-$(checksum requirements.txt)
+  cd ../
+  rm -rf semaphore-demo-python-django
+}
+
+@test "cache - autostore/autorestore [nodejs]" {
+
+  git clone git@github.com:semaphoreci-demos/semaphore-demo-javascript.git
+  cd semaphore-demo-javascript/src/client/
+
+  npm install > /dev/null
+
+  run cache store
+
+  assert_success
+  assert_output --partial "* Detected package-lock.json"
+  assert_output --partial "Upload complete."
+
+  rm -rf node_modules
+
+  run cache restore
+  assert_success
+  assert_output --partial "* Fetching 'node_modules' directory with cache keys"
+  assert_output --partial "Restored: node_modules/"
+
+  run cache delete node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum package-lock.json)
+  cd ../../../
+  rm -rf semaphore-demo-javascript
+}
+
+@test "cache - autostore/autorestore [elixir]" {
+
+  git clone git@github.com:semaphoreci-demos/semaphore-demo-elixir-phoenix.git
+  cd semaphore-demo-elixir-phoenix
+  mix deps.get > /dev/null
+
+  run cache store
+
+  assert_success
+  assert_output --partial "* Detected mix.lock"
+  assert_output --partial "Upload complete."
+
+  rm -rf deps
+
+  run cache restore
+  assert_success
+  assert_output --partial "* Fetching 'deps' directory with cache keys"
+  assert_output --partial "Restored: deps/"
+
+  run cache delete deps-$SEMAPHORE_GIT_BRANCH-$(checksum mix.lock)
+  cd ../
+  rm -rf semaphore-demo-elixir-phoenix
+}
+
+@test "cache - autostore/autorestore [php]" {
+
+  git clone git@github.com:semaphoreci-demos/semaphore-demo-php-laravel.git
+  cd semaphore-demo-php-laravel
+  composer install > /dev/null || true
+
+  run cache store
+
+  assert_success
+  assert_output --partial "* Detected composer.lock"
+  assert_output --partial "Upload complete."
+
+  sudo rm -rf .pip_cache
+
+  run cache restore
+  assert_success
+  assert_output --partial "* Fetching 'vendor' directory with cache keys"
+  assert_output --partial "Restored: vendor/"
+
+  run cache delete requirements-$SEMAPHORE_GIT_BRANCH-$(checksum composer.lock)
+  cd ../
+  rm -rf semaphore-demo-php-laravel
+}

--- a/tests/cache.bats
+++ b/tests/cache.bats
@@ -5,8 +5,6 @@ load "support/bats-assert/load"
 
 teardown() {
   rm -rf tmp
-  rm -rf semaphore-demo-ruby-rails
-  rm -rf semaphore-demo-python-django
   ./cache delete bats-test-$SEMAPHORE_GIT_BRANCH
   ./cache delete bats-test-$SEMAPHORE_GIT_BRANCH-1
   unset CACHE_SIZE

--- a/tests/cache.bats
+++ b/tests/cache.bats
@@ -5,6 +5,8 @@ load "support/bats-assert/load"
 
 teardown() {
   rm -rf tmp
+  rm -rf semaphore-demo-ruby-rails
+  rm -rf semaphore-demo-python-django
   ./cache delete bats-test-$SEMAPHORE_GIT_BRANCH
   ./cache delete bats-test-$SEMAPHORE_GIT_BRANCH-1
   unset CACHE_SIZE


### PR DESCRIPTION
Improve current caching mechanism - detecting project structure and storing dependencies into cache when `cache store` or `cache restore` is called without any additional arguments

example usage: 

based on https://docs.semaphoreci.com/article/99-rails-continuous-integration
```
blocks:
  - name: Setup
    task:
      jobs:
        - name: bundle
          commands:
          - checkout
          - cache restore
          - sem-version ruby 2.6.0
          - bundle install --deployment -j 4 --path vendor/bundle
          - cache store
```