### PR TITLE
Fix cache command for macOS

### DIFF
--- a/cache
+++ b/cache
@@ -311,7 +311,20 @@ cache::delete_oldest_key() {
  cache::lftp "glob rm -f ${key}"
 
  cache::log "Key ${key} is deleted."
- sed -i '$d' $file
+ DIST=$(uname)
+ case $DIST in
+   Darwin)
+     sed -i "" '$d' $file
+     ;;
+   Linux)
+     sed -i '$d' $file
+    ;;
+   *)
+     echo "Unsupported distro $DIST"
+     exit 1
+   ;;
+ esac
+
  echo $size
 }
 


### PR DESCRIPTION
Fix issue with the macOS cache command failing when removing old keys.