### PR TITLE
update install-toolbox to install without sudo

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -21,7 +21,7 @@ blocks:
       - name: Test artifact CLI installation
         commands:
           - ls artifact.tar.gz || true
-          - artifact | grep "Semaphore 2.0 Artifact CLI"
+          - artifact -h
 
       - name: Bats tests
         commands:

--- a/install-toolbox
+++ b/install-toolbox
@@ -5,56 +5,49 @@ IFS=$'\n\t'
 
 DIST=$(uname)
 
-case $DIST in
-  Darwin)
-    INSTALL_PATH='/usr/local/bin'
-    ;;
-  Linux)
-    INSTALL_PATH='/usr/bin'
-   ;;
-  *)
-    echo "Unsupported distro $DIST"
-    exit 1
-  ;;
-esac
-
 cat << EOF >> ~/.ssh/config
 Host github.com bitbucket.org
   StrictHostKeyChecking no
   UserKnownHostsFile=/dev/null
 EOF
 
-install_cmd() {
-  local cmd=$@
-  if [ `whoami` == 'root' ]; then
-    `$@`
-  else
-    `sudo $@`
-  fi
+install_toolbox() {
+  ln -sf ~/.toolbox/retry $INSTALL_PATH/retry
+  chmod +x $INSTALL_PATH/retry
+
+  ln -sf ~/.toolbox/ssh-session-cli $INSTALL_PATH/semaphore
+  chmod +x $INSTALL_PATH/semaphore
+
+  ln -sf ~/.toolbox/cache $INSTALL_PATH/cache
+  chmod +x $INSTALL_PATH/cache
+
+  ln -sf ~/.toolbox/sem-service $INSTALL_PATH/sem-service
+  chmod +x $INSTALL_PATH/sem-service
 }
 
-install_cmd ln -sf ~/.toolbox/retry $INSTALL_PATH/retry
-install_cmd chmod +x $INSTALL_PATH/retry
+install_artifacts() {
+  case $DIST in
+    Linux)
+      ARTIFCAT_RELEASE=$(curl -s "https://api.github.com/repos/semaphoreci/artifact/releases/latest" | grep "browser_download_url" | grep $DIST | cut -d : -f 2,3 | tr -d '"' | tr -d " ")
+      curl -s -L --retry 5 -o artifact.tar.gz $ARTIFCAT_RELEASE
+      tar xzf artifact.tar.gz
+      mv artifact $INSTALL_PATH/artifact
+      chmod +x $INSTALL_PATH/artifact
+      rm -f artifact.tar.gz LICENSE README.md
+      ;;
+    *)
+      echo ""
+      ;;
+  esac
+}
 
-install_cmd ln -sf ~/.toolbox/ssh-session-cli $INSTALL_PATH/semaphore
-install_cmd chmod +x $INSTALL_PATH/semaphore
+if [ `whoami` == 'root' ]; then
+  INSTALL_PATH="/usr/bin"
+else
+  INSTALL_PATH="$HOME/.semaphoreci_bin"
+  mkdir -p $INSTALL_PATH
+  echo "export PATH=\"\$PATH:$INSTALL_PATH\"" >> ~/.semaphoreci_profile
+fi
 
-install_cmd ln -sf ~/.toolbox/cache $INSTALL_PATH/cache
-install_cmd chmod +x $INSTALL_PATH/cache
-
-install_cmd ln -sf ~/.toolbox/sem-service $INSTALL_PATH/sem-service
-install_cmd chmod +x $INSTALL_PATH/sem-service
-
-
-case $DIST in
-  Darwin)
-    echo ""
-    ;;
-  Linux)
-    install_cmd curl -s -L --retry 5 -o artifact.tar.gz https://github.com/semaphoreci/artifact/releases/download/v0.2.5/artifact_Linux_x86_64.tar.gz
-    install_cmd tar xzf artifact.tar.gz
-    install_cmd mv artifact $INSTALL_PATH/artifact
-    install_cmd chmod +x $INSTALL_PATH/artifact
-    install_cmd rm -f artifact.tar.gz LICENSE README.md
-   ;;
-esac
+install_toolbox
+install_artifacts

--- a/install-toolbox
+++ b/install-toolbox
@@ -5,49 +5,60 @@ IFS=$'\n\t'
 
 DIST=$(uname)
 
+case $DIST in
+  Darwin)
+    INSTALL_PATH='/usr/local/bin'
+    ;;
+  Linux)
+    INSTALL_PATH='/usr/bin'
+   ;;
+  *)
+    echo "Unsupported distro $DIST"
+    exit 1
+  ;;
+esac
+
 cat << EOF >> ~/.ssh/config
 Host github.com bitbucket.org
   StrictHostKeyChecking no
   UserKnownHostsFile=/dev/null
 EOF
 
-install_toolbox() {
-  ln -sf ~/.toolbox/retry $INSTALL_PATH/retry
-  chmod +x $INSTALL_PATH/retry
-
-  ln -sf ~/.toolbox/ssh-session-cli $INSTALL_PATH/semaphore
-  chmod +x $INSTALL_PATH/semaphore
-
-  ln -sf ~/.toolbox/cache $INSTALL_PATH/cache
-  chmod +x $INSTALL_PATH/cache
-
-  ln -sf ~/.toolbox/sem-service $INSTALL_PATH/sem-service
-  chmod +x $INSTALL_PATH/sem-service
+install_cmd() {
+  local cmd=$@
+  if [ `whoami` == 'root' ]; then
+    `$@`
+  elif [[ $SEMAPHORE_AGENT_MACHINE_ENVIRONMENT_TYPE == "container" ]]; then
+    INSTALL_PATH="$HOME/.semaphoreci_bin"
+    mkdir -p $INSTALL_PATH
+    echo "export PATH=\"\$PATH:$INSTALL_PATH\"" >> ~/.semaphoreci_profile
+  else
+    `sudo $@`
+  fi
 }
 
-install_artifacts() {
-  case $DIST in
-    Linux)
-      ARTIFCAT_RELEASE=$(curl -s "https://api.github.com/repos/semaphoreci/artifact/releases/latest" | grep "browser_download_url" | grep $DIST | cut -d : -f 2,3 | tr -d '"' | tr -d " ")
-      curl -s -L --retry 5 -o artifact.tar.gz $ARTIFCAT_RELEASE
-      tar xzf artifact.tar.gz
-      mv artifact $INSTALL_PATH/artifact
-      chmod +x $INSTALL_PATH/artifact
-      rm -f artifact.tar.gz LICENSE README.md
-      ;;
-    *)
-      echo ""
-      ;;
-  esac
-}
+install_cmd ln -sf ~/.toolbox/retry $INSTALL_PATH/retry
+install_cmd chmod +x $INSTALL_PATH/retry
 
-if [ `whoami` == 'root' ]; then
-  INSTALL_PATH="/usr/bin"
-else
-  INSTALL_PATH="$HOME/.semaphoreci_bin"
-  mkdir -p $INSTALL_PATH
-  echo "export PATH=\"\$PATH:$INSTALL_PATH\"" >> ~/.semaphoreci_profile
-fi
+install_cmd ln -sf ~/.toolbox/ssh-session-cli $INSTALL_PATH/semaphore
+install_cmd chmod +x $INSTALL_PATH/semaphore
 
-install_toolbox
-install_artifacts
+install_cmd ln -sf ~/.toolbox/cache $INSTALL_PATH/cache
+install_cmd chmod +x $INSTALL_PATH/cache
+
+install_cmd ln -sf ~/.toolbox/sem-service $INSTALL_PATH/sem-service
+install_cmd chmod +x $INSTALL_PATH/sem-service
+
+case $DIST in
+  Darwin)
+    echo ""
+    ;;
+  Linux)
+  ARTIFCAT_RELEASE=$(curl -s "https://api.github.com/repos/semaphoreci/artifact/releases/latest" | grep "browser_download_url" | grep $DIST | cut -d : -f 2,3 | tr -d '"' | tr -d " ")
+  install_cmd curl -s -L --retry 5 -o artifact.tar.gz $ARTIFCAT_RELEASE
+  install_cmd tar xzf artifact.tar.gz
+  install_cmd mv artifact $INSTALL_PATH/artifact
+  install_cmd chmod +x $INSTALL_PATH/artifact
+  install_cmd rm -f artifact.tar.gz LICENSE README.md
+   ;;
+esac

--- a/toolbox
+++ b/toolbox
@@ -1,3 +1,6 @@
 source ~/.toolbox/sem-version
 source ~/.toolbox/libcheckout
 source ~/.toolbox/libchecksum
+if [[ -f ~/.semaphoreci_profile ]]; then
+  source ~/.semaphoreci_profile
+fi


### PR DESCRIPTION
Updated the `install-toolbox` script to install toolbox utils inside local user dir without sudo if running inside container as unprivileged user. if running inside the container as `root` or as a semaphore user on a regular VM, toolbox installation behaviour is unchanged.

To help determine if we are running inside a container or a VM, a new environment variable was introduced: `SEMAPHORE_AGENT_MACHINE_ENVIRONMENT_TYPE` which can have a value of:
`container` or `VM`.

docs ref: https://docs.semaphoreci.com/article/12-environment-variables#semaphore_agent_machine_environment_type