### PR TITLE
Revert "update install-toolbox to install without sudo"

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -21,7 +21,7 @@ blocks:
       - name: Test artifact CLI installation
         commands:
           - ls artifact.tar.gz || true
-          - artifact -h
+          - artifact | grep "Semaphore 2.0 Artifact CLI"
 
       - name: Bats tests
         commands:

--- a/install-toolbox
+++ b/install-toolbox
@@ -28,10 +28,6 @@ install_cmd() {
   local cmd=$@
   if [ `whoami` == 'root' ]; then
     `$@`
-  elif [[ $SEMAPHORE_AGENT_MACHINE_ENVIRONMENT_TYPE == "container" ]]; then
-    INSTALL_PATH="$HOME/.semaphoreci_bin"
-    mkdir -p $INSTALL_PATH
-    echo "export PATH=\"\$PATH:$INSTALL_PATH\"" >> ~/.semaphoreci_profile
   else
     `sudo $@`
   fi
@@ -49,16 +45,16 @@ install_cmd chmod +x $INSTALL_PATH/cache
 install_cmd ln -sf ~/.toolbox/sem-service $INSTALL_PATH/sem-service
 install_cmd chmod +x $INSTALL_PATH/sem-service
 
+
 case $DIST in
   Darwin)
     echo ""
     ;;
   Linux)
-  ARTIFCAT_RELEASE=$(curl -s "https://api.github.com/repos/semaphoreci/artifact/releases/latest" | grep "browser_download_url" | grep $DIST | cut -d : -f 2,3 | tr -d '"' | tr -d " ")
-  install_cmd curl -s -L --retry 5 -o artifact.tar.gz $ARTIFCAT_RELEASE
-  install_cmd tar xzf artifact.tar.gz
-  install_cmd mv artifact $INSTALL_PATH/artifact
-  install_cmd chmod +x $INSTALL_PATH/artifact
-  install_cmd rm -f artifact.tar.gz LICENSE README.md
+    install_cmd curl -s -L --retry 5 -o artifact.tar.gz https://github.com/semaphoreci/artifact/releases/download/v0.2.5/artifact_Linux_x86_64.tar.gz
+    install_cmd tar xzf artifact.tar.gz
+    install_cmd mv artifact $INSTALL_PATH/artifact
+    install_cmd chmod +x $INSTALL_PATH/artifact
+    install_cmd rm -f artifact.tar.gz LICENSE README.md
    ;;
 esac

--- a/toolbox
+++ b/toolbox
@@ -1,6 +1,3 @@
 source ~/.toolbox/sem-version
 source ~/.toolbox/libcheckout
 source ~/.toolbox/libchecksum
-if [[ -f ~/.semaphoreci_profile ]]; then
-  source ~/.semaphoreci_profile
-fi


### PR DESCRIPTION
Reverts semaphoreci/toolbox#110

Reverting this PR. We got one report that the cache CLI is not installed in a container. I'm not yet 100% sure that this is the cause, but the safest option for now, is to revert.