### PR TITLE
rectify install path for toolbox install

### DIFF
--- a/install-toolbox
+++ b/install-toolbox
@@ -34,6 +34,7 @@ install_cmd() {
   if [ `whoami` == 'root' ]; then
     `$@`
   elif [[ $SEMAPHORE_AGENT_MACHINE_ENVIRONMENT_TYPE == "container" ]]; then
+    touch ~/.semaphoreci_profile
     [ "`grep -c semaphoreci ~/.semaphoreci_profile`" -eq 0 ] && echo "export PATH=\"\$PATH:$INSTALL_PATH\"" >> ~/.semaphoreci_profile
     `$@`
   else

--- a/install-toolbox
+++ b/install-toolbox
@@ -18,6 +18,11 @@ case $DIST in
   ;;
 esac
 
+if [ $SEMAPHORE_AGENT_MACHINE_ENVIRONMENT_TYPE == "container" ]; then
+  INSTALL_PATH="$HOME/.semaphoreci_bin"
+  mkdir -p $INSTALL_PATH
+fi
+
 cat << EOF >> ~/.ssh/config
 Host github.com bitbucket.org
   StrictHostKeyChecking no
@@ -27,6 +32,9 @@ EOF
 install_cmd() {
   local cmd=$@
   if [ `whoami` == 'root' ]; then
+    `$@`
+  elif [[ $SEMAPHORE_AGENT_MACHINE_ENVIRONMENT_TYPE == "container" ]]; then
+    [ "`grep -c semaphoreci ~/.semaphoreci_profile`" -eq 0 ] && echo "export PATH=\"\$PATH:$INSTALL_PATH\"" >> ~/.semaphoreci_profile
     `$@`
   else
     `sudo $@`

--- a/toolbox
+++ b/toolbox
@@ -1,3 +1,6 @@
 source ~/.toolbox/sem-version
 source ~/.toolbox/libcheckout
 source ~/.toolbox/libchecksum
+if [[ -f ~/.semaphoreci_profile ]]; then
+   source ~/.semaphoreci_profile
+ fi


### PR DESCRIPTION
INSTALL_PATH is now reset after the platform check is finished, creating
the missing folder with it if need be. This also keeps the INSTALL_PATH changes isolated to the top section, leaving the `install_cmd` to smaller set of things to do.

the command was not run for the container environment thus ... not adding links to the tools anymore so this introduces it back

finally, to avoid adding multiple times the install path in the PATH a
quick grep check on the profile will limit runs to only once