### PR TITLE
add caching support for nvm

### DIFF
--- a/cache
+++ b/cache
@@ -22,7 +22,7 @@ E_FLAE=0 # file already exists
 DATE_FORMAT='%H:%M %d/%m/%Y'
 
 # Lockfiles to lookup for autostore and autoresotre
-LOCKFILES=('.nvmrc', 'Gemfile.lock' 'package-lock.json' 'yarn.lock' 'mix.lock' 'requirements.txt' 'composer.lock' 'pom.xml')
+LOCKFILES=('.nvmrc' 'Gemfile.lock' 'package-lock.json' 'yarn.lock' 'mix.lock' 'requirements.txt' 'composer.lock' 'pom.xml')
 
 # Dist
 DIST=$(uname)

--- a/cache
+++ b/cache
@@ -65,6 +65,17 @@ cache::autostore() {
   for lockfile in ${LOCKFILES[@]}; do
     if [[ -f $lockfile ]]; then
         case $lockfile in
+          ".nvmrc")
+            cache::log
+            cache::log "* Detected $lockfile."
+            SEMAPHORE_LOCAL_CACHE_PATHS="$HOME/.nvm"
+            cache::log "* Using default cache path '$SEMAPHORE_LOCAL_CACHE_PATHS'."
+            if [[ -d $SEMAPHORE_LOCAL_CACHE_PATHS ]]; then
+              SEMAPHORE_CACHE_KEY=$(cache::normalize_string nvm-$SEMAPHORE_GIT_BRANCH-$(checksum .nvmrc))
+              cache::lftp_put
+            else
+              cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to store in cache."
+            fi
           "Gemfile.lock")
             cache::log
             cache::log "* Detected $lockfile."

--- a/cache
+++ b/cache
@@ -22,7 +22,7 @@ E_FLAE=0 # file already exists
 DATE_FORMAT='%H:%M %d/%m/%Y'
 
 # Lockfiles to lookup for autostore and autoresotre
-LOCKFILES=('Gemfile.lock' 'package-lock.json' 'yarn.lock' 'mix.lock' 'requirements.txt' 'composer.lock' 'pom.xml')
+LOCKFILES=('.nvmrc', 'Gemfile.lock' 'package-lock.json' 'yarn.lock' 'mix.lock' 'requirements.txt' 'composer.lock' 'pom.xml')
 
 # Dist
 DIST=$(uname)
@@ -186,6 +186,12 @@ cache::autorestore() {
   for lockfile in ${LOCKFILES[@]}; do
     if [[ -f $lockfile ]]; then
         case $lockfile in
+          ".nvmrc")
+            cache::log
+            cache::log "* Detected $lockfile."
+            cache::log "* Fetching '~/.nvm' directory with cache keys 'nvm-${SEMAPHORE_GIT_BRANCH}-$(checksum .nvmrc),nvm-${SEMAPHORE_GIT_BRANCH},nvm-master'."
+            SEMAPHORE_LOCAL_CACHE_PATHS="$HOME/.nvm"
+            cache::restore nvm-${SEMAPHORE_GIT_BRANCH}-$(checksum .nvmrc),nvm-${SEMAPHORE_GIT_BRANCH},nvm-master
           "Gemfile.lock")
             cache::log
             cache::log "* Detected $lockfile."

--- a/cache
+++ b/cache
@@ -76,6 +76,7 @@ cache::autostore() {
             else
               cache::log "* WARNING!!! Default cache path: $SEMAPHORE_LOCAL_CACHE_PATHS not found, nothing to store in cache."
             fi
+            ;;
           "Gemfile.lock")
             cache::log
             cache::log "* Detected $lockfile."
@@ -203,6 +204,7 @@ cache::autorestore() {
             cache::log "* Fetching '~/.nvm' directory with cache keys 'nvm-${SEMAPHORE_GIT_BRANCH}-$(checksum .nvmrc),nvm-${SEMAPHORE_GIT_BRANCH},nvm-master'."
             SEMAPHORE_LOCAL_CACHE_PATHS="$HOME/.nvm"
             cache::restore nvm-${SEMAPHORE_GIT_BRANCH}-$(checksum .nvmrc),nvm-${SEMAPHORE_GIT_BRANCH},nvm-master
+            ;;
           "Gemfile.lock")
             cache::log
             cache::log "* Detected $lockfile."


### PR DESCRIPTION
Currently nvm can be used in Semaphore2, but the default cache does not make use of it. Many node projects need to add support for nvm manually, as they want their tests to run on a specific version of nodejs.

This PR adds support for detecting and caching nvm files.