### PR TITLE
Check if image is present locally

### DIFF
--- a/sem-service
+++ b/sem-service
@@ -14,7 +14,11 @@ service::pull_image() {
     service::err "Invalid image name provided '${image_name}'"
   fi
 
-  service::duration service::run_cmd docker pull $image_name download $(echo ${image_name%%:*})
+  local name="$(echo $image_name | cut -d':' -f1)"
+  local  tag="$(echo $image_name | cut -d':' -f2)"
+  if [ "$(docker image ls | grep $image | awk '{print $2}')" != "$tag" ]; then  
+    service::duration service::run_cmd docker pull $image_name download $(echo ${image_name%%:*})
+  fi
 }
 
 service::start_mysql() {

--- a/sem-service
+++ b/sem-service
@@ -16,7 +16,7 @@ service::pull_image() {
 
   local name="$(echo $image_name | cut -d':' -f1)"
   local  tag="$(echo $image_name | cut -d':' -f2)"
-  if [ "$(docker image ls | grep $image | awk '{print $2}')" != "$tag" ]; then  
+  if [ "$(docker image ls | grep $name | awk '{print $2}')" != "$tag" ]; then  
     service::duration service::run_cmd docker pull $image_name download $(echo ${image_name%%:*})
   fi
 }


### PR DESCRIPTION
When an image is already present (mounted), and there is a slightly newer version, sem-service downloads the newer one (same version, for ex mysql:5.6) although there is no need for it , costing extra time.
This modification checks if the image with the version is already in place and downloads only if it isn't.