### PR TITLE
Multiple cache restore support 

### DIFF
--- a/cache
+++ b/cache
@@ -449,14 +449,14 @@ Fallback example:
     cache::err "Incorrect number of arguments!"
   else
     semaphore_cache_keys=$1
-    cache::download "keys" "/tmp/cache_keys"
+    cache::download "keys" "/tmp/cache_keys_$$"
 
     for key in ${semaphore_cache_keys//,/ }; do
       cache_key=$(cache::normalize_string $key)
-      match=$(grep -m 1 ${cache_key} /tmp/cache_keys)
+      match=$(grep -m 1 ${cache_key} /tmp/cache_keys_$$)
 
       if [[ ! -z "${match}" ]]; then
-        exact_match=$(grep -x ${cache_key} /tmp/cache_keys)
+        exact_match=$(grep -x ${cache_key} /tmp/cache_keys_$$)
 
         if [[ "${exact_match}" == "${cache_key}" ]]; then
           cache::log "HIT: ${cache_key}, using key ${cache_key}"
@@ -473,7 +473,7 @@ Fallback example:
       fi
     done
 
-    rm -f /tmp/cache_keys
+    rm -f /tmp/cache_keys_$$
   fi
 }
 


### PR DESCRIPTION
This allows the cache restore command to be used multiple times at the same time.  ie:

```
cache restore bundle-cache-master &
cache restore yarn-cache-master &
```

We have found that this allows our Semaphore build to improve by 1-2 minutes, helping us to get to a 10min build.