### PR TITLE
Simple System Metrics Collector

### DIFF
--- a/install-toolbox
+++ b/install-toolbox
@@ -104,20 +104,5 @@ else
   echo "toolbox_install_error{module='artifacts'} 1" >> /tmp/toolbox_metrics
 fi
 
-#
-# Installing the simple system metrics collector.
-#
-
-echo "Installing the Simple System Metrics Collector"
-
-install_cmd ln -sf ~/.toolbox/system-metrics-collector /usr/bin/system-metrics-collector
-install_cmd chmod +x /usr/bin/system-metrics-collector
-
-if [[ $? -eq 0 ]];then
-  echo "system-metrics-collector installed"
-else
-  echo "toolbox_install_error{module='system-metrics-collector'} 1" >> /tmp/toolbox_metrics
-fi
-
 echo "Starting to collect System Metrics in /tmp/system-metrics"
-system-metrics-collector & # failure won't be propagated to the caller in case of using &
+sh ~/toolbox/system-metrics-collector & # failure won't be propagated to the caller in case of using &

--- a/install-toolbox
+++ b/install-toolbox
@@ -37,7 +37,7 @@ install_cmd() {
 
 install_cmd ln -sf ~/.toolbox/retry $INSTALL_PATH/retry
 install_cmd chmod +x $INSTALL_PATH/retry
-if [[ $? -eq 0 ]];then 
+if [[ $? -eq 0 ]];then
   echo "retry installed"
 else
   echo "toolbox_install_error{module='retry'} 1" >> /tmp/toolbox_metrics
@@ -45,7 +45,7 @@ fi
 
 install_cmd ln -sf ~/.toolbox/ssh-session-cli $INSTALL_PATH/semaphore
 install_cmd chmod +x $INSTALL_PATH/semaphore
-if [[ $? -eq 0 ]];then 
+if [[ $? -eq 0 ]];then
   echo "ssh-session-cli installed"
 else
   echo "toolbox_install_error{module='ssh-session-cli'} 1" >> /tmp/toolbox_metrics
@@ -54,7 +54,7 @@ fi
 
 install_cmd ln -sf ~/.toolbox/cache $INSTALL_PATH/cache
 install_cmd chmod +x $INSTALL_PATH/cache
-if [[ $? -eq 0 ]];then 
+if [[ $? -eq 0 ]];then
   echo "cache installed"
 else
   echo "toolbox_install_error{module='cache'} 1" >> /tmp/toolbox_metrics
@@ -63,7 +63,7 @@ fi
 
 install_cmd ln -sf ~/.toolbox/sem-service $INSTALL_PATH/sem-service
 install_cmd chmod +x $INSTALL_PATH/sem-service
-if [[ $? -eq 0 ]];then 
+if [[ $? -eq 0 ]];then
   echo "sem-service installed"
 else
   echo "toolbox_install_error{module='sem-service'} 1" >> /tmp/toolbox_metrics
@@ -72,7 +72,7 @@ fi
 
 install_cmd ln -sf ~/.toolbox/sem-dockerize $INSTALL_PATH/sem-dockerize
 install_cmd chmod +x $INSTALL_PATH/sem-dockerize
-if [[ $? -eq 0 ]];then 
+if [[ $? -eq 0 ]];then
   echo "sem-dockerize installed"
 else
   echo "toolbox_install_error{module='sem-dockerize'} 1" >> /tmp/toolbox_metrics
@@ -81,11 +81,15 @@ fi
 
 install_cmd ln -sf ~/.toolbox/sem-service-check-params $INSTALL_PATH/sem-service-check-params
 install_cmd chmod +x $INSTALL_PATH/sem-service-check-params
-if [[ $? -eq 0 ]];then 
+if [[ $? -eq 0 ]];then
   echo "sem-service-check-params installed"
 else
   echo "toolbox_install_error{module='sem-service-check-params'} 1" >> /tmp/toolbox_metrics
 fi
+
+#
+# Installing the Artifacts CLI.
+#
 
 echo "Installing the artifacts CLI"
 echo "Using http://packages.semaphoreci.com/${ARTIFACT_CLI_VERSION}/artifact_${DIST}_x86_64.tar.gz"
@@ -94,11 +98,26 @@ install_cmd tar xzf artifact.tar.gz
 install_cmd mv artifact $INSTALL_PATH/artifact
 install_cmd chmod +x $INSTALL_PATH/artifact
 install_cmd rm -f artifact.tar.gz LICENSE README.md
-if [[ $? -eq 0 ]];then 
+if [[ $? -eq 0 ]];then
   echo "artifacts installed"
 else
-  echo "toolbox_install_error{module='artifacts} 1" >> /tmp/toolbox_metrics
+  echo "toolbox_install_error{module='artifacts'} 1" >> /tmp/toolbox_metrics
 fi
 
+#
+# Installing the simple system metrics collector.
+#
 
+echo "Installing the Simple System Metrics Collector"
 
+install_cmd ln -sf ~/.toolbox/system-metrics-collector /usr/bin/system-metrics-collector
+install_cmd chmod +x /usr/bin/system-metrics-collector
+
+if [[ $? -eq 0 ]];then
+  echo "system-metrics-collector installed"
+else
+  echo "toolbox_install_error{module='system-metrics-collector'} 1" >> /tmp/toolbox_metrics
+fi
+
+echo "Starting to collect System Metrics in /tmp/system-metrics"
+system-metrics-collector & # failure won't be propagated to the caller in case of using &

--- a/system-metrics-collector
+++ b/system-metrics-collector
@@ -29,7 +29,7 @@ while true; do
   MEMORY=$(free | grep Mem | awk '{ printf("%6.2f%%\n", ($3/$2 * 100.0)) }')
   DISK=$(df | grep "$DISK_NAME" | awk '{ printf("%6.2f%%\n", ($3/$2 * 100.0)) }')
 
-  echo "$(date) | mem: $MEMORY, disk: $DISK" >>
+  echo "$(date) | mem: $MEMORY, disk: $DISK" >> $OUTPUT
 
   sleep 30
 done

--- a/system-metrics-collector
+++ b/system-metrics-collector
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+#
+# Simple log system metrics collector. Polls the system state every 30s and
+# saves the result to /tmp/system-metrics.
+#
+# The simple nature of the script allows it to seemlesly run in any Linux based
+# VM, Docker image, or on a MacVM host.
+#
+# The recommended way to start the script is to run it in the background.
+#
+#   $ system-metrics-collector &
+#
+# The resulting file's format is the following:
+#
+#   $ cat /tmp/system-metrics-collector
+#
+#     Mon May 18 14:50:58 UTC 2020 | mem:   5.03%, disk:  47.75%
+#     Mon May 18 14:51:28 UTC 2020 | mem:   5.03%, disk:  47.75%
+#
+# Jobs that run for an hour collect around 120 log lines. This should be safe
+# and not introduce any performance of disk usage problems.
+#
+
+DISK_NAME="/dev/mapper/semaphore--vm--vg-root"
+OUTPUT="/tmp/system-metrics"
+
+while true; do
+  MEMORY=$(free | grep Mem | awk '{ printf("%6.2f%%\n", ($3/$2 * 100.0)) }')
+  DISK=$(df | grep "$DISK_NAME" | awk '{ printf("%6.2f%%\n", ($3/$2 * 100.0)) }')
+
+  echo "$(date) | mem: $MEMORY, disk: $DISK" >>
+
+  sleep 30
+done


### PR DESCRIPTION
A very thin agent for collecting system metrics. This agent should be able to work in any Docker image, Linux VM or on Mac OS.

Metrics are collected in `/tmp/system-metrics`. These metrics can be used in two ways:

- In the userspace by adding `cat /tmp/system-metrics` as an epilogue command.
- In the inspection state, extracted from running VMs.

The metrics can offer valuable basic insights into the state of the Jobs and potentialy uncover problems.

---

Futher advancements in this area could be to change to format to JSON, collect and display these metrics in the UI.