### PR TITLE
Use process specific temp files to fix concurrency issues

### DIFF
--- a/cache
+++ b/cache
@@ -347,14 +347,14 @@ cache::allocate_space() {
 
   archive_size=$1
 
-  file="/tmp/keys_data"
+  file="/tmp/keys_data_$$"
   cache::save_command_output "cls --sort=date -l" $file
-  echo -e "$(cat $file | awk '{print $5}')" > "/tmp/usage_data"
-  echo -e "$(cat $file | awk '{print $5, $9}')" > "/tmp/size_key"
+  echo -e "$(cat $file | awk '{print $5}')" > "/tmp/usage_data_$$"
+  echo -e "$(cat $file | awk '{print $5, $9}')" > "/tmp/size_key_$$"
 
-  used_space=$(cache::used_space "/tmp/usage_data")
+  used_space=$(cache::used_space "/tmp/usage_data_$$")
   free_space=$(cache::free_space ${used_space})
-  rm -f "/tmp/usage_data"
+  rm -f "/tmp/usage_data_$$"
 
   if [ $free_space -lt $archive_size ]; then
     cache::log "Not enough space, deleting the oldest keys."
@@ -364,18 +364,18 @@ cache::allocate_space() {
     done
   fi
 
-  rm -f /tmp/size_key
-  rm -f /tmp/keys_data
+  rm -f /tmp/size_key_$$
+  rm -f /tmp/keys_data_$$
 }
 
 cache::delete_oldest_key() {
  local key
  local file
 
- file=/tmp/size_key
+ file=/tmp/size_key_$$
 
- size=$(cat /tmp/size_key | tail -1 | awk '{ print $1 }')
- key=$(cat /tmp/size_key | tail -1 | awk '{ print $2 }')
+ size=$(cat /tmp/size_key_$$ | tail -1 | awk '{ print $1 }')
+ key=$(cat /tmp/size_key_$$ | tail -1 | awk '{ print $2 }')
  cache::lftp "glob rm -f ${key}"
 
  cache::warn "Key ${key} is deleted."
@@ -504,10 +504,10 @@ cache::clear() {
 
 cache::list() {
   if cache::is_not_empty; then
-    cache::download "list" "/tmp/list_data"
-    output=$(cat /tmp/list_data)
+    cache::download "list" "/tmp/list_data_$$"
+    output=$(cat /tmp/list_data_$$)
     cache::log "${output}"
-    rm -f /tmp/list_data
+    rm -f /tmp/list_data_$$
   else
     cache::log "Cache is empty."
   fi
@@ -520,7 +520,7 @@ cache::usage() {
   local hr_free_space
   local file
 
-  file="/tmp/usage_data"
+  file="/tmp/usage_data_$$"
   cache::download "usage" $file
 
   used_space=$(cache::used_space $file)


### PR DESCRIPTION
In an attempt to speed up the builds, we run a number of commands concurrently.  This causes issues with some cache commands, as shown below.

In this code, we call `cache store..` 3 times and if the cache is full we can hit issues as the filename is shared by all the processes and one of them can delete the file causing the others to error.  Following PR adds a process id to all temp filenames that appear relevant.

I haven't tested yet, but can generate a patch and apply on the fly if you feel this is needed.

```
Not enough space, deleting the oldest keys.
Key yarn-master-d379f217bbd4cfc991a37e185150bb47 is deleted.
Uploading '/home/semaphore/chopin/public/' with cache key 'public-master-4391c85f-9024-490c-bb9d-55a439aea4f1'...
Key node-modules-master-d379f217bbd4cfc991a37e185150bb47 is deleted.
sed: can't read /tmp/size_key: No such file or directory
cat: /tmp/size_key: No such file or directory
cat: /tmp/size_key: No such file or directory
sed: can't read /tmp/size_key: No such file or directory
/usr/bin/cache: line 363: 342985431 + : syntax error: operand expected (error token is "+ ")
Upload complete.
Uploading '/home/semaphore/.cache/yarn' with cache key 'yarn-master-d379f217bbd4cfc991a37e185150bb47'...
Upload complete.
Not enough space, deleting the oldest keys.
Key public-master-7a76fc9b-14b7-4cc2-be52-5f1ecf6f9e03 is deleted.
Key public-master-e33b958a-f250-41a5-b0a8-e341e80b92f3 is deleted.
Key public-master-9bec0bb6-44cc-4602-b624-b8cdab372944 is deleted.
Key public-master-6e2a7d9e-2461-43ac-8a38-6420139c8b4e is deleted.
Key public-master-e2ec0cb8-e816-4a64-b137-b4bac6ea0c6a is deleted.
Key bootsnap-d030045da02df4be3e7c860f0094d0fc is deleted.
Uploading 'tmp/cache' with cache key 'bootsnap-9d4ff7de4afbd8fce7316198484dd450'...
Upload complete.
Uploading 'node_modules' with cache key 'node-modules-master-d379f217bbd4cfc991a37e185150bb47'...
Upload complete.
```