### PR TITLE
Add Semaphore Pipeline Compiler to the Toolbox

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -241,6 +241,19 @@ blocks:
           commands:
             - bats --tap --timing $TEST
 
+  - name: Semaphore Compiler
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - bash release/install_in_tests.sh
+
+      jobs:
+        - name: Check if installed
+          commands:
+            - whereis spc
+            - whereis when
+
 promotions:
   - name: Release
     pipeline_file: release.yml

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -251,8 +251,8 @@ blocks:
       jobs:
         - name: Check if installed
           commands:
-            - whereis spc
-            - whereis when
+            - which spc
+            - which when
 
 promotions:
   - name: Release

--- a/install-toolbox
+++ b/install-toolbox
@@ -96,10 +96,6 @@ else
 fi
 
 
-#
-# Installing the Artifacts CLI.
-#
-
 echo "Installing the artifacts CLI"
 install_cmd mv ~/.toolbox/artifact $INSTALL_PATH/artifact
 install_cmd chmod +x $INSTALL_PATH/artifact
@@ -108,6 +104,26 @@ if [[ $? -eq 0 ]];then
 else
   echo "toolbox_install_error{module='artifacts'} 1" >> /tmp/toolbox_metrics
 fi
+
+
+echo "Installing the artifacts CLI"
+install_cmd mv ~/.toolbox/spc $INSTALL_PATH/spc
+install_cmd chmod +x $INSTALL_PATH/spc
+if [[ $? -eq 0 ]];then
+  echo "spc installed"
+else
+  echo "toolbox_install_error{module='spc'} 1" >> /tmp/toolbox_metrics
+fi
+
+echo "Installing the when CLI"
+install_cmd mv ~/.toolbox/when $INSTALL_PATH/when
+install_cmd chmod +x $INSTALL_PATH/when
+if [[ $? -eq 0 ]];then
+  echo "when installed"
+else
+  echo "toolbox_install_error{module='when'} 1" >> /tmp/toolbox_metrics
+fi
+
 
 if [[ `uname` != "Darwin" ]]; then
   echo "Starting to collect System Metrics in /tmp/system-metrics"

--- a/release/create.sh
+++ b/release/create.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 ARTIFACT_CLI_VERSION="v0.4.0"
 ARTIFACT_CLI_URL="https://github.com/semaphoreci/artifact/releases/download/$ARTIFACT_CLI_VERSION"
 
+SPC_CLI_VERSION="v1.0.0"
+SPC_CLI_URL="https://github.com/semaphoreci/spc/releases/download/$SPC_CLI_VERSION"
+
 #
 # Create release dirs
 #
@@ -44,6 +47,17 @@ curl -s -L --retry 5 $ARTIFACT_CLI_URL/artifact_Darwin_x86_64.tar.gz -o /tmp/Dar
 
 cd /tmp/Linux && tar -zxf artifact_Linux.tar.gz && mv artifact toolbox/ && cd -
 cd /tmp/Darwin && tar -zxf artifact_Darwin.tar.gz && mv artifact toolbox/ && cd -
+
+#
+# Download and add SPC CLI to the release
+#
+echo "Download SPC CLI"
+
+curl -s -L --retry 5 $SPC_CLI_VERSION/spc_Linux_x86_64.tar.gz -o /tmp/Linux/spc_Linux.tar.gz
+curl -s -L --retry 5 $SPC_CLI_VERSION/spc_Darwin_x86_64.tar.gz -o /tmp/Darwin/spc_Darwin.tar.gz
+
+cd /tmp/Linux && tar -zxf spc_Linux.tar.gz && mv spc toolbox/ && cd -
+cd /tmp/Darwin && tar -zxf spc_Darwin.tar.gz && mv spc toolbox/ && cd -
 
 #
 # Create linux release

--- a/release/create.sh
+++ b/release/create.sh
@@ -3,12 +3,11 @@
 set -euo pipefail
 
 ARTIFACT_CLI_VERSION="v0.4.0"
-ARTIFACT_CLI_URL="https://github.com/semaphoreci/artifact/releases/download/$ARTIFACT_CLI_VERSION"
-
-SPC_CLI_VERSION="v1.0.0"
-SPC_CLI_URL="https://github.com/semaphoreci/spc/releases/download/$SPC_CLI_VERSION"
-
 WHEN_CLI_VERSION="v0.0.2-alpha"
+SPC_CLI_VERSION="v1.0.1"
+
+ARTIFACT_CLI_URL="https://github.com/semaphoreci/artifact/releases/download/$ARTIFACT_CLI_VERSION"
+SPC_CLI_URL="https://github.com/semaphoreci/spc/releases/download/$SPC_CLI_VERSION"
 WHEN_CLI_URL="https://github.com/renderedtext/when/releases/download/$WHEN_CLI_VERSION"
 
 #

--- a/release/create.sh
+++ b/release/create.sh
@@ -8,6 +8,9 @@ ARTIFACT_CLI_URL="https://github.com/semaphoreci/artifact/releases/download/$ART
 SPC_CLI_VERSION="v1.0.0"
 SPC_CLI_URL="https://github.com/semaphoreci/spc/releases/download/$SPC_CLI_VERSION"
 
+WHEN_CLI_VERSION="v0.0.2-alpha"
+WHEN_CLI_URL="https://github.com/renderedtext/when/releases/download/$WHEN_CLI_VERSION"
+
 #
 # Create release dirs
 #
@@ -49,12 +52,23 @@ cd /tmp/Linux && tar -zxf artifact_Linux.tar.gz && mv artifact toolbox/ && cd -
 cd /tmp/Darwin && tar -zxf artifact_Darwin.tar.gz && mv artifact toolbox/ && cd -
 
 #
+# Download and add When CLI to the release
+#
+echo "Download When CLI"
+
+curl -s -L --retry 5 $WHEN_CLI_URL/when -o /tmp/Linux/toolbox/when
+curl -s -L --retry 5 $WHEN_CLI_URL/when -o /tmp/Darwin/toolbox/when
+
+chmod +x /tmp/Linux/toolbox/when
+chmod +x /tmp/Darwin/toolbox/when
+
+#
 # Download and add SPC CLI to the release
 #
 echo "Download SPC CLI"
 
-curl -s -L --retry 5 $SPC_CLI_VERSION/spc_Linux_x86_64.tar.gz -o /tmp/Linux/spc_Linux.tar.gz
-curl -s -L --retry 5 $SPC_CLI_VERSION/spc_Darwin_x86_64.tar.gz -o /tmp/Darwin/spc_Darwin.tar.gz
+curl -s -L --retry 5 $SPC_CLI_URL/spc_Linux_x86_64.tar.gz -o /tmp/Linux/spc_Linux.tar.gz
+curl -s -L --retry 5 $SPC_CLI_URL/spc_Darwin_x86_64.tar.gz -o /tmp/Darwin/spc_Darwin.tar.gz
 
 cd /tmp/Linux && tar -zxf spc_Linux.tar.gz && mv spc toolbox/ && cd -
 cd /tmp/Darwin && tar -zxf spc_Darwin.tar.gz && mv spc toolbox/ && cd -


### PR DESCRIPTION
The newly introduced compile stage (example: https://semaphore.semaphoreci.com/workflows/af0e81c1-84a6-4e81-a5bf-acc3bb1603a2) needs these two CLIs in the Toolbox to work efficiently.

We are adding:

- Semaphore Pipeline Compiler (SPC): Compiles change_in expressions in Pipelines
- When: Evaluates "when" expressions in pipelines