### PR TITLE
Smoke tests for artifacts

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -158,6 +158,7 @@ blocks:
                 - tests/macos_cache.bats
                 - tests/macos_autocache.bats
                 - tests/libcheckout.bats
+                - tests/artifacts.bats
 
           commands:
             - bats --tap --timing $TEST
@@ -185,6 +186,7 @@ blocks:
               values:
                 - tests/cache.bats
                 - tests/libcheckout.bats
+                - tests/artifacts.bats
           commands:
             - bats --tap --timing $TEST
 
@@ -212,6 +214,7 @@ blocks:
               values:
                 - tests/cache.bats
                 - tests/libcheckout.bats
+                - tests/artifacts.bats
           commands:
             - bats --tap --timing $TEST
 
@@ -238,6 +241,7 @@ blocks:
                 - tests/cache.bats
                 - tests/libcheckout.bats
                 - tests/base.bats
+                - tests/artifacts.bats
           commands:
             - bats --tap --timing $TEST
 

--- a/tests/artifacts.bats
+++ b/tests/artifacts.bats
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+
+load "support/bats-support/load"
+load "support/bats-assert/load"
+
+@test "artifacts - uploading to proect level" {
+  run artifact push project ~/.toolbox/retry
+}
+
+@test "artifacts - uploading to workflows level" {
+  run artifact push workflows ~/.toolbox/retry
+}
+
+@test "artifacts - uploading to job level" {
+  run artifact push job ~/.toolbox/retry
+}
+


### PR DESCRIPTION
Not a full-fledged test, but enough to verify basic binary compatibility like GLIBC versions.