### PR TITLE
php,ruby bump

### DIFF
--- a/sem-version
+++ b/sem-version
@@ -42,9 +42,9 @@ version::change() {
 }
 version::change_ruby() {
   [[ "$software_version" == "2.5" ]] && software_version="2.5.9"
-  [[ "$software_version" == "2.6" ]] && software_version="2.6.7"
-  [[ "$software_version" == "2.7" ]] && software_version="2.7.3"
-  [[ "$software_version" == "3.0" ]] && software_version="3.0.1"
+  [[ "$software_version" == "2.6" ]] && software_version="2.6.8"
+  [[ "$software_version" == "2.7" ]] && software_version="2.7.4"
+  [[ "$software_version" == "3.0" ]] && software_version="3.0.2"
 
   if ! [ -d ~/.rbenv/versions/"${software_version}" ]; then
     sem-install ruby "${software_version}"
@@ -79,10 +79,10 @@ version::change_php() {
   [[ "$software_version" == "7.0" ]] && software_version="7.0.33"
   [[ "$software_version" == "7.1" ]] && software_version="7.1.33"
   [[ "$software_version" == "7.2" ]] && software_version="7.2.34"
-  [[ "$software_version" == "7.3" ]] && software_version="7.3.27"
-  [[ "$software_version" == "7.4" ]] && software_version="7.4.18"
-  [[ "$software_version" == "8" ]] && software_version="8.0.5"
-  [[ "$software_version" == "8.0" ]] && software_version="8.0.5"
+  [[ "$software_version" == "7.3" ]] && software_version="7.3.29"
+  [[ "$software_version" == "7.4" ]] && software_version="7.4.21"
+  [[ "$software_version" == "8" ]] && software_version="8.0.8"
+  [[ "$software_version" == "8.0" ]] && software_version="8.0.8"
 
   if ! [ -d ~/.phpbrew/php/php-"${software_version}" ]; then
     sem-install php "${software_version}"

--- a/tests/sem_version_bionic.bats
+++ b/tests/sem_version_bionic.bats
@@ -51,28 +51,28 @@ setup() {
   assert_line --partial "ruby 2.5.3"
 }
 
-@test "change ruby to 2.3.7" {
+@test "change ruby to 2.3.8" {
 
-  run sem-version ruby 2.3.7
+  run sem-version ruby 2.3.8
   assert_success
   run ruby --version
-  assert_line --partial "ruby 2.3.7"
+  assert_line --partial "ruby 2.3.8"
 }
 
-@test "change ruby to 2.7.3" {
+@test "change ruby to 2.7.4" {
 
-  run sem-version ruby 2.7.3
+  run sem-version ruby 2.7.4
   assert_success
   run ruby --version
-  assert_line --partial "ruby 2.7.3"
+  assert_line --partial "ruby 2.7.4"
 }
 
-@test "change ruby to 3.0.1" {
+@test "change ruby to 3.0.2" {
 
-  run sem-version ruby 3.0.1
+  run sem-version ruby 3.0.2
   assert_success
   run ruby --version
-  assert_line --partial "ruby 3.0.1"
+  assert_line --partial "ruby 3.0.2"
 }
 @test "ruby minor versions test" {
 
@@ -84,17 +84,17 @@ setup() {
   run sem-version ruby 2.6
   assert_success
   run ruby --version
-  assert_line --partial "ruby 2.6.7"
+  assert_line --partial "ruby 2.6.8"
 
   run sem-version ruby 2.7
   assert_success
   run ruby --version
-  assert_line --partial "ruby 2.7.3"
+  assert_line --partial "ruby 2.7.4"
 
   run sem-version ruby 3.0
   assert_success
   run ruby --version
-  assert_line --partial "ruby 3.0.1"
+  assert_line --partial "ruby 3.0.2"
 
 }
 
@@ -120,35 +120,59 @@ setup() {
 }
 
 # PHP
-@test "change php to 7.3.27" {
+@test "change php to 7.2.34" {
 
-  run sem-version php 7.3.27
+  run sem-version php 7.2.34
   assert_success
   source ~/.phpbrew/bashrc
   run php -v
-  assert_line --partial "PHP 7.3.27"
+  assert_line --partial "PHP 7.2.34"
+  run php -m
+  assert_line --partial "magick"
+  assert_line --partial "gd"
+  assert_line --partial "imap"
+}
+@test "change php to 7.3.29" {
+
+  run sem-version php 7.3.29
+  assert_success
+  source ~/.phpbrew/bashrc
+  run php -v
+  assert_line --partial "PHP 7.3.29"
+  run php -m
+  assert_line --partial "magick"
+  assert_line --partial "gd"
+  assert_line --partial "imap"
+}
+@test "change php to 7.4.21" {
+
+  run sem-version php 7.4.21
+  assert_success
+  source ~/.phpbrew/bashrc
+  run php -v
+  assert_line --partial "PHP 7.4.21"
   run php -m 
   assert_line --partial "magick"
   assert_line --partial "gd"
   assert_line --partial "imap"
 }
-@test "change php to 8.0.5" {
+@test "change php to 8.0.8" {
 
-  run sem-version php 8.0.5
+  run sem-version php 8.0.8
   assert_success
   source ~/.phpbrew/bashrc
   run php -v
-  assert_line --partial "PHP 8.0.5"
+  assert_line --partial "PHP 8.0.8"
   run php -m 
   assert_line --partial "gd"
   assert_line --partial "imap"
 }
-@test "php check composer 8.0.5" {
+@test "php check composer 8.0.8" {
 
   run which composer
   assert_success
   source ~/.phpbrew/bashrc
-  assert_line --partial "8.0.5"
+  assert_line --partial "8.0.8"
 }
 
 #  Elixir


### PR DESCRIPTION
sem-version alias change for Ruby and PHP and tests update
Ruby: 2.6.8, 2.7.4, 3.0.2
PHP: 7.3.29, 7.4.21, 8.0.8