### PR TITLE
Update flutter test

### DIFF
--- a/tests/sem_version_container.bats
+++ b/tests/sem_version_container.bats
@@ -14,11 +14,11 @@ setup() {
   assert_line --partial "2.2.3"
 }
 
-@test "sem-version flutter 2.5.1" {
+@test "sem-version flutter 2.5.2" {
 
-  run sem-version flutter 2.5.1
+  run sem-version flutter 2.5.2
   assert_success
-  assert_line --partial "2.5.1"
+  assert_line --partial "2.5.2"
 }
 
 


### PR DESCRIPTION
The `sem-version flutter 2.5.1` test started failing yesterday. Looking at the VM, I see no version 2.5.1 around, only version 2.5.2:

```
root@545c4daf02fe:~# ls -la /opt/
total 28
drwxr-xr-x 1 root root 4096 Oct  5 13:00 .
drwxr-xr-x 1 root root 4096 Oct  6 17:32 ..
drwxr-xr-x 1 root root 4096 Oct  5 12:58 android-sdk-linux
lrwxrwxrwx 1 root root   18 Oct  5 13:00 flutter -> /opt/flutter_2.5.2
drwxr-xr-x 1 1022 1023 4096 Jul  1 22:29 flutter_2.2.3
drwxr-xr-x 1 1009 1010 4096 Sep 30 23:34 flutter_2.5.2
drwxr-xr-x 3 root root 4096 Oct  5 12:52 gradle
drwxr-xr-x 1 root root 4096 Oct  5 12:56 rubies
```

Possibly related to [this commit](https://github.com/renderedtext/dockerfile-renderer/commit/39d53141df5afa88698edfc5614a190083fd1c8d).