### PR TITLE
Windows cache CLI support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,6 @@ jobs:
         env:
           SEMAPHORE_CACHE_S3_URL: "http://127.0.0.1:9000"
         run: |
+          Get-Process minio
           cd cache-cli
           gotestsum --format short-verbose --packages="./..." -- -p 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,10 @@ jobs:
           New-Item C:\minio -ItemType Directory
           Invoke-WebRequest "https://dl.min.io/server/minio/release/windows-amd64/minio.exe" -OutFile C:\minio\minio.exe
           New-Item C:\minio\data\semaphore-cache -ItemType Directory
-          Start-Process C:\minio\minio.exe -ArgumentList 'server','C:\minio\data' -RedirectStandardOutput C:\minio\logs -RedirectStandardError C:\minio\logs
+          Start-Process C:\minio\minio.exe -ArgumentList 'server','C:\minio\data' -RedirectStandardOutput C:\minio\logs -RedirectStandardError C:\minio\errors
           sleep 5
           type C:\minio\logs
+          type C:\minio\errors
           Get-Process minio
       - name: Test
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,20 +12,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
-      - name: Install & run minio
+      - name: Run tests
+        env:
+          SEMAPHORE_CACHE_S3_URL: "http://127.0.0.1:9000"
         run: |
           New-Item C:\minio -ItemType Directory
           Invoke-WebRequest "https://dl.min.io/server/minio/release/windows-amd64/minio.exe" -OutFile C:\minio\minio.exe
           New-Item C:\minio\data\semaphore-cache -ItemType Directory
           Start-Process C:\minio\minio.exe -ArgumentList 'server','C:\minio\data' -RedirectStandardOutput C:\minio\logs -RedirectStandardError C:\minio\errors
-          sleep 5
-          type C:\minio\logs
-          type C:\minio\errors
-          Get-Process minio
-      - name: Test
-        env:
-          SEMAPHORE_CACHE_S3_URL: "http://127.0.0.1:9000"
-        run: |
-          Get-Process minio
           cd cache-cli
           gotestsum --format short-verbose --packages="./..." -- -p 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
           Start-Process C:\minio\minio.exe -ArgumentList 'server','C:\minio\data' -RedirectStandardOutput C:\minio\logs
       - name: Test
         run: |
+          Get-Process minio
+          type C:\minio\logs
           cd cache-cli
           $env:SEMAPHORE_CACHE_S3_URL = "http://localhost:9000"
           gotestsum --format short-verbose --packages="./..." -- -p 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,13 @@ jobs:
           New-Item C:\minio -ItemType Directory
           Invoke-WebRequest "https://dl.min.io/server/minio/release/windows-amd64/minio.exe" -OutFile C:\minio\minio.exe
           New-Item C:\minio\data\semaphore-cache -ItemType Directory
-          Start-Process C:\minio\minio.exe -ArgumentList 'server','C:\minio\data' -RedirectStandardOutput C:\minio\logs
-      - name: Test
-        run: |
-          Get-Process minio
+          Start-Process C:\minio\minio.exe -ArgumentList 'server','C:\minio\data' -RedirectStandardOutput C:\minio\logs -RedirectStandardError C:\minio\logs
+          sleep 5
           type C:\minio\logs
+          Get-Process minio
+      - name: Test
+        env:
+          SEMAPHORE_CACHE_S3_URL: "http://127.0.0.1:9000"
+        run: |
           cd cache-cli
-          $env:SEMAPHORE_CACHE_S3_URL = "http://localhost:9000"
           gotestsum --format short-verbose --packages="./..." -- -p 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+on: [push]
+name: Unit tests
+jobs:
+  unit-testing:
+    runs-on: windows-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+      - name: Install & run minio
+        run: |
+          New-Item C:\minio -ItemType Directory
+          Invoke-WebRequest "https://dl.min.io/server/minio/release/windows-amd64/minio.exe" -OutFile C:\minio\minio.exe
+          New-Item C:\minio\data\semaphore-cache -ItemType Directory
+          Start-Process C:\minio\minio.exe -ArgumentList 'server','C:\minio\data' -RedirectStandardOutput C:\minio\logs
+      - name: Test
+        run: |
+          cd cache-cli
+          $env:SEMAPHORE_CACHE_S3_URL = "http://localhost:9000"
+          gotestsum --format short-verbose --packages="./..." -- -p 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
         env:
           SEMAPHORE_CACHE_S3_URL: "http://127.0.0.1:9000"
         run: |
-          New-Item C:\minio -ItemType Directory
+          New-Item C:\minio -ItemType Directory > $null
           Invoke-WebRequest "https://dl.min.io/server/minio/release/windows-amd64/minio.exe" -OutFile C:\minio\minio.exe
-          New-Item C:\minio\data\semaphore-cache -ItemType Directory
+          New-Item C:\minio\data\semaphore-cache -ItemType Directory > $null
           Start-Process C:\minio\minio.exe -ArgumentList 'server','C:\minio\data' -RedirectStandardOutput C:\minio\logs -RedirectStandardError C:\minio\errors
           cd cache-cli
           gotestsum --format short-verbose --packages="./..." -- -p 1

--- a/.semaphore/release.yml
+++ b/.semaphore/release.yml
@@ -16,5 +16,6 @@ blocks:
             - checkout
             - artifact pull workflow bin/linux/cache -d cache-cli/bin/linux/cache
             - artifact pull workflow bin/darwin/cache -d cache-cli/bin/darwin/cache
+            - artifact pull workflow bin/windows/cache.exe -d cache-cli/bin/windows/cache.exe
             - bash release/create.sh -a
             - bash release/upload.sh

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -22,10 +22,12 @@ blocks:
         - name: Build cache CLI
           commands:
             - cd cache-cli
-            - make build OS=linux
-            - make build OS=darwin
+            - make build.linux
+            - make build.darwin
+            - make build.windows
             - artifact push workflow bin/linux/cache -d bin/linux/cache
             - artifact push workflow bin/darwin/cache -d bin/darwin/cache
+            - artifact push workflow bin/windows/cache.exe -d bin/windows/cache.exe
 
   - name: Static Code Analysis
     dependencies: []

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -21,8 +21,6 @@ blocks:
       jobs:
         - name: Build cache CLI
           commands:
-            # Add bad command to not run all these jobs when we are only interested in the Windows jobs
-            - asdasdasd
             - cd cache-cli
             - make build.linux
             - make build.darwin

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -21,6 +21,8 @@ blocks:
       jobs:
         - name: Build cache CLI
           commands:
+            # Add bad command to not run all these jobs when we are only interested in the Windows jobs
+            - asdasdasd
             - cd cache-cli
             - make build.linux
             - make build.darwin

--- a/cache-cli/Makefile
+++ b/cache-cli/Makefile
@@ -29,8 +29,14 @@ test:
 test.watch:
 	docker-compose run --rm cli gotestsum --watch --format short-verbose --junitfile junit-report.xml --packages="./..." -- -p 1
 
-build:
-	CGO_ENABLED=0 GOOS=$(OS) go build -o bin/$(OS)/cache main.go
+build.darwin:
+	CGO_ENABLED=0 GOOS=darwin go build -o bin/darwin/cache main.go
+
+build.linux:
+	CGO_ENABLED=0 GOOS=linux go build -o bin/linux/cache main.go
+
+build.windows:
+	CGO_ENABLED=0 GOOS=windows go build -o bin/windows/cache.exe main.go
 
 lint:
 	revive -formatter friendly -config lint.toml ./...

--- a/cache-cli/cmd/clear_test.go
+++ b/cache-cli/cmd/clear_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/semaphoreci/toolbox/cache-cli/pkg/storage"
@@ -27,7 +28,7 @@ func Test__Clear(t *testing.T) {
 			err := storage.Clear()
 			assert.Nil(t, err)
 
-			tempFile, _ := ioutil.TempFile("/tmp", "*")
+			tempFile, _ := ioutil.TempFile(os.TempDir(), "*")
 			storage.Store("abc001", tempFile.Name())
 
 			capturer := utils.CreateOutputCapturer()

--- a/cache-cli/cmd/delete_test.go
+++ b/cache-cli/cmd/delete_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/semaphoreci/toolbox/cache-cli/pkg/storage"
@@ -22,7 +23,7 @@ func Test__Delete(t *testing.T) {
 
 		t.Run(fmt.Sprintf("%s key is present", backend), func(*testing.T) {
 			storage.Clear()
-			tempFile, _ := ioutil.TempFile("/tmp", "*")
+			tempFile, _ := ioutil.TempFile(os.TempDir(), "*")
 			storage.Store("abc001", tempFile.Name())
 
 			capturer := utils.CreateOutputCapturer()
@@ -34,7 +35,7 @@ func Test__Delete(t *testing.T) {
 
 		t.Run(fmt.Sprintf("%s normalizes key", backend), func(*testing.T) {
 			storage.Clear()
-			tempFile, _ := ioutil.TempFile("/tmp", "*")
+			tempFile, _ := ioutil.TempFile(os.TempDir(), "*")
 			RunStore(storeCmd, []string{"abc/00/33", tempFile.Name()})
 
 			capturer := utils.CreateOutputCapturer()

--- a/cache-cli/cmd/has_key_test.go
+++ b/cache-cli/cmd/has_key_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/semaphoreci/toolbox/cache-cli/pkg/storage"
@@ -22,7 +23,7 @@ func Test__HasKey(t *testing.T) {
 
 		t.Run(fmt.Sprintf("%s key is present", backend), func(*testing.T) {
 			storage.Clear()
-			tempFile, _ := ioutil.TempFile("/tmp", "*")
+			tempFile, _ := ioutil.TempFile(os.TempDir(), "*")
 			storage.Store("abc001", tempFile.Name())
 
 			capturer := utils.CreateOutputCapturer()
@@ -34,7 +35,7 @@ func Test__HasKey(t *testing.T) {
 
 		t.Run(fmt.Sprintf("%s normalizes key", backend), func(*testing.T) {
 			storage.Clear()
-			tempFile, _ := ioutil.TempFile("/tmp", "*")
+			tempFile, _ := ioutil.TempFile(os.TempDir(), "*")
 			RunStore(storeCmd, []string{"abc/00/33", tempFile.Name()})
 
 			capturer := utils.CreateOutputCapturer()

--- a/cache-cli/cmd/is_not_empty_test.go
+++ b/cache-cli/cmd/is_not_empty_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/semaphoreci/toolbox/cache-cli/pkg/storage"
@@ -18,7 +19,7 @@ func Test__IsNotEmpty(t *testing.T) {
 
 		t.Run(fmt.Sprintf("%s cache is not empty", backend), func(*testing.T) {
 			storage.Clear()
-			tempFile, _ := ioutil.TempFile("/tmp", "*")
+			tempFile, _ := ioutil.TempFile(os.TempDir(), "*")
 			storage.Store("abc001", tempFile.Name())
 
 			assert.True(t, RunIsNotEmpty(isNotEmptyCmd, []string{}))

--- a/cache-cli/cmd/list_test.go
+++ b/cache-cli/cmd/list_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/semaphoreci/toolbox/cache-cli/pkg/storage"
@@ -24,7 +25,7 @@ func Test__List(t *testing.T) {
 
 		t.Run(fmt.Sprintf("%s with keys", backend), func(*testing.T) {
 			storage.Clear()
-			tempFile, _ := ioutil.TempFile("/tmp", "*")
+			tempFile, _ := ioutil.TempFile(os.TempDir(), "*")
 			storage.Store("abc001", tempFile.Name())
 			storage.Store("abc002", tempFile.Name())
 			storage.Store("abc003", tempFile.Name())

--- a/cache-cli/cmd/restore_test.go
+++ b/cache-cli/cmd/restore_test.go
@@ -47,8 +47,9 @@ func Test__Restore(t *testing.T) {
 			RunRestore(restoreCmd, []string{"abc-001"})
 			output := capturer.Done()
 
+			restoredPath := filepath.FromSlash(fmt.Sprintf("%s/", tempDir))
 			assert.Contains(t, output, "HIT: 'abc-001', using key 'abc-001'.")
-			assert.Contains(t, output, fmt.Sprintf("Restored: %s/.", tempDir))
+			assert.Contains(t, output, fmt.Sprintf("Restored: %s.", restoredPath))
 
 			os.Remove(tempFile.Name())
 			os.Remove(tempDir)
@@ -67,9 +68,10 @@ func Test__Restore(t *testing.T) {
 			RunRestore(restoreCmd, []string{"abc/00/22"})
 			output := capturer.Done()
 
+			restoredPath := filepath.FromSlash(fmt.Sprintf("%s/", tempDir))
 			assert.Contains(t, output, "Key 'abc/00/22' is normalized to 'abc-00-22'")
 			assert.Contains(t, output, "HIT: 'abc-00-22', using key 'abc-00-22'.")
-			assert.Contains(t, output, fmt.Sprintf("Restored: %s/.", tempDir))
+			assert.Contains(t, output, fmt.Sprintf("Restored: %s.", restoredPath))
 
 			os.Remove(tempFile.Name())
 			os.Remove(tempDir)
@@ -88,8 +90,9 @@ func Test__Restore(t *testing.T) {
 			RunRestore(restoreCmd, []string{"abc"})
 			output := capturer.Done()
 
+			restoredPath := filepath.FromSlash(fmt.Sprintf("%s/", tempDir))
 			assert.Contains(t, output, "HIT: 'abc', using key 'abc-001'.")
-			assert.Contains(t, output, fmt.Sprintf("Restored: %s/.", tempDir))
+			assert.Contains(t, output, fmt.Sprintf("Restored: %s.", restoredPath))
 
 			os.Remove(tempFile.Name())
 			os.Remove(tempDir)
@@ -109,8 +112,9 @@ func Test__Restore(t *testing.T) {
 			RunRestore(restoreCmd, []string{"abc-001,abc-002"})
 			output := capturer.Done()
 
+			restoredPath := filepath.FromSlash(fmt.Sprintf("%s/", tempDir))
 			assert.Contains(t, output, "HIT: 'abc-001', using key 'abc-001'.")
-			assert.Contains(t, output, fmt.Sprintf("Restored: %s/.", tempDir))
+			assert.Contains(t, output, fmt.Sprintf("Restored: %s.", restoredPath))
 			assert.NotContains(t, output, "HIT: 'abc-002', using key 'abc-002'.")
 
 			os.Remove(tempFile.Name())
@@ -130,9 +134,10 @@ func Test__Restore(t *testing.T) {
 			RunRestore(restoreCmd, []string{"abc-001,abc"})
 			output := capturer.Done()
 
+			restoredPath := filepath.FromSlash(fmt.Sprintf("%s/", tempDir))
 			assert.Contains(t, output, "MISS: 'abc-001'.")
 			assert.Contains(t, output, "HIT: 'abc', using key 'abc'.")
-			assert.Contains(t, output, fmt.Sprintf("Restored: %s/.", tempDir))
+			assert.Contains(t, output, fmt.Sprintf("Restored: %s.", restoredPath))
 
 			os.Remove(tempFile.Name())
 			os.Remove(tempDir)
@@ -151,8 +156,9 @@ func Test__Restore(t *testing.T) {
 			RunRestore(restoreCmd, []string{"^abc"})
 			output := capturer.Done()
 
+			restoredPath := filepath.FromSlash(fmt.Sprintf("%s/", tempDir))
 			assert.Contains(t, output, "HIT: '^abc', using key 'abc'.")
-			assert.Contains(t, output, fmt.Sprintf("Restored: %s/.", tempDir))
+			assert.Contains(t, output, fmt.Sprintf("Restored: %s.", restoredPath))
 
 			os.Remove(tempFile.Name())
 			os.Remove(tempDir)
@@ -197,7 +203,7 @@ func Test__AutomaticRestore(t *testing.T) {
 
 			assert.Contains(t, output, "Detected Gemfile.lock")
 			assert.Contains(t, output, fmt.Sprintf("Downloading key '%s'", key))
-			assert.Contains(t, output, "Restored: vendor/bundle")
+			assert.Contains(t, output, fmt.Sprintf("Restored: %s", filepath.FromSlash("vendor/bundle")))
 
 			os.RemoveAll("vendor")
 			os.Remove(compressedFile)

--- a/cache-cli/cmd/restore_test.go
+++ b/cache-cli/cmd/restore_test.go
@@ -39,6 +39,7 @@ func Test__Restore(t *testing.T) {
 
 			tempDir, _ := ioutil.TempDir(os.TempDir(), "*")
 			tempFile, _ := ioutil.TempFile(tempDir, "*")
+			_ = tempFile.Close()
 
 			compressAndStore(storage, "abc-001", tempDir)
 
@@ -58,6 +59,7 @@ func Test__Restore(t *testing.T) {
 
 			tempDir, _ := ioutil.TempDir(os.TempDir(), "*")
 			tempFile, _ := ioutil.TempFile(tempDir, "*")
+			_ = tempFile.Close()
 
 			compressAndStore(storage, "abc/00/22", tempDir)
 
@@ -78,6 +80,7 @@ func Test__Restore(t *testing.T) {
 
 			tempDir, _ := ioutil.TempDir(os.TempDir(), "*")
 			tempFile, _ := ioutil.TempFile(tempDir, "*")
+			_ = tempFile.Close()
 
 			compressAndStore(storage, "abc-001", tempDir)
 
@@ -97,6 +100,7 @@ func Test__Restore(t *testing.T) {
 
 			tempDir, _ := ioutil.TempDir(os.TempDir(), "*")
 			tempFile, _ := ioutil.TempFile(tempDir, "*")
+			_ = tempFile.Close()
 
 			compressAndStore(storage, "abc-001", tempDir)
 			compressAndStore(storage, "abc-002", tempDir)
@@ -118,6 +122,7 @@ func Test__Restore(t *testing.T) {
 
 			tempDir, _ := ioutil.TempDir(os.TempDir(), "*")
 			tempFile, _ := ioutil.TempFile(tempDir, "*")
+			_ = tempFile.Close()
 
 			compressAndStore(storage, "abc", tempDir)
 
@@ -138,6 +143,7 @@ func Test__Restore(t *testing.T) {
 
 			tempDir, _ := ioutil.TempDir(os.TempDir(), "*")
 			tempFile, _ := ioutil.TempFile(tempDir, "*")
+			_ = tempFile.Close()
 
 			compressAndStore(storage, "abc", tempDir)
 

--- a/cache-cli/cmd/restore_test.go
+++ b/cache-cli/cmd/restore_test.go
@@ -37,7 +37,7 @@ func Test__Restore(t *testing.T) {
 		t.Run(fmt.Sprintf("%s using single exact key", backend), func(*testing.T) {
 			storage.Clear()
 
-			tempDir, _ := ioutil.TempDir("/tmp", "*")
+			tempDir, _ := ioutil.TempDir(os.TempDir(), "*")
 			tempFile, _ := ioutil.TempFile(tempDir, "*")
 
 			compressAndStore(storage, "abc-001", tempDir)
@@ -56,7 +56,7 @@ func Test__Restore(t *testing.T) {
 		t.Run(fmt.Sprintf("%s normalizes key", backend), func(*testing.T) {
 			storage.Clear()
 
-			tempDir, _ := ioutil.TempDir("/tmp", "*")
+			tempDir, _ := ioutil.TempDir(os.TempDir(), "*")
 			tempFile, _ := ioutil.TempFile(tempDir, "*")
 
 			compressAndStore(storage, "abc/00/22", tempDir)
@@ -76,7 +76,7 @@ func Test__Restore(t *testing.T) {
 		t.Run(fmt.Sprintf("%s using single matching key", backend), func(*testing.T) {
 			storage.Clear()
 
-			tempDir, _ := ioutil.TempDir("/tmp", "*")
+			tempDir, _ := ioutil.TempDir(os.TempDir(), "*")
 			tempFile, _ := ioutil.TempFile(tempDir, "*")
 
 			compressAndStore(storage, "abc-001", tempDir)
@@ -95,7 +95,7 @@ func Test__Restore(t *testing.T) {
 		t.Run(fmt.Sprintf("%s only first matching key is used", backend), func(*testing.T) {
 			storage.Clear()
 
-			tempDir, _ := ioutil.TempDir("/tmp", "*")
+			tempDir, _ := ioutil.TempDir(os.TempDir(), "*")
 			tempFile, _ := ioutil.TempFile(tempDir, "*")
 
 			compressAndStore(storage, "abc-001", tempDir)
@@ -116,7 +116,7 @@ func Test__Restore(t *testing.T) {
 		t.Run(fmt.Sprintf("%s using fallback key", backend), func(*testing.T) {
 			storage.Clear()
 
-			tempDir, _ := ioutil.TempDir("/tmp", "*")
+			tempDir, _ := ioutil.TempDir(os.TempDir(), "*")
 			tempFile, _ := ioutil.TempFile(tempDir, "*")
 
 			compressAndStore(storage, "abc", tempDir)
@@ -136,7 +136,7 @@ func Test__Restore(t *testing.T) {
 		t.Run(fmt.Sprintf("%s using regex key", backend), func(*testing.T) {
 			storage.Clear()
 
-			tempDir, _ := ioutil.TempDir("/tmp", "*")
+			tempDir, _ := ioutil.TempDir(os.TempDir(), "*")
 			tempFile, _ := ioutil.TempFile(tempDir, "*")
 
 			compressAndStore(storage, "abc", tempDir)

--- a/cache-cli/cmd/root_test.go
+++ b/cache-cli/cmd/root_test.go
@@ -2,36 +2,51 @@ package cmd
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/semaphoreci/toolbox/cache-cli/pkg/storage"
 	assert "github.com/stretchr/testify/assert"
 )
 
-var testBackend = map[string]map[string]string{
+type TestBackend struct {
+	envVars      map[string]string
+	runInWindows bool
+}
+
+var testBackends = map[string]TestBackend{
 	"s3": {
-		"SEMAPHORE_PROJECT_NAME":    "cache-cli",
-		"SEMAPHORE_CACHE_BACKEND":   "s3",
-		"SEMAPHORE_CACHE_S3_URL":    "http://s3:9000",
-		"SEMAPHORE_CACHE_S3_BUCKET": "semaphore-cache",
+		runInWindows: true,
+		envVars: map[string]string{
+			"SEMAPHORE_PROJECT_NAME":    "cache-cli",
+			"SEMAPHORE_CACHE_BACKEND":   "s3",
+			"SEMAPHORE_CACHE_S3_URL":    "http://s3:9000",
+			"SEMAPHORE_CACHE_S3_BUCKET": "semaphore-cache",
+		},
 	},
 	"sftp": {
-		"SEMAPHORE_CACHE_BACKEND":          "sftp",
-		"SEMAPHORE_CACHE_URL":              "sftp-server:22",
-		"SEMAPHORE_CACHE_USERNAME":         "tester",
-		"SEMAPHORE_CACHE_PRIVATE_KEY_PATH": "/root/.ssh/semaphore_cache_key",
+		runInWindows: false,
+		envVars: map[string]string{
+			"SEMAPHORE_CACHE_BACKEND":          "sftp",
+			"SEMAPHORE_CACHE_URL":              "sftp-server:22",
+			"SEMAPHORE_CACHE_USERNAME":         "tester",
+			"SEMAPHORE_CACHE_PRIVATE_KEY_PATH": "/root/.ssh/semaphore_cache_key",
+		},
 	},
 }
 
 func runTestForAllBackends(t *testing.T, test func(string, storage.Storage)) {
-	for backend, envVars := range testBackend {
-		for envVarName, envVarValue := range envVars {
+	for backendType, testBackend := range testBackends {
+		if runtime.GOOS == "windows" && !testBackend.runInWindows {
+			continue
+		}
+
+		for envVarName, envVarValue := range testBackend.envVars {
 			os.Setenv(envVarName, envVarValue)
 		}
 
 		storage, err := storage.InitStorage()
 		assert.Nil(t, err)
-
-		test(backend, storage)
+		test(backendType, storage)
 	}
 }

--- a/cache-cli/cmd/root_test.go
+++ b/cache-cli/cmd/root_test.go
@@ -20,7 +20,7 @@ var testBackends = map[string]TestBackend{
 		envVars: map[string]string{
 			"SEMAPHORE_PROJECT_NAME":    "cache-cli",
 			"SEMAPHORE_CACHE_BACKEND":   "s3",
-			"SEMAPHORE_CACHE_S3_URL":    "http://s3:9000",
+			"SEMAPHORE_CACHE_S3_URL":    os.Getenv("SEMAPHORE_CACHE_S3_URL"),
 			"SEMAPHORE_CACHE_S3_BUCKET": "semaphore-cache",
 		},
 	},

--- a/cache-cli/cmd/store.go
+++ b/cache-cli/cmd/store.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -52,7 +53,8 @@ func RunStore(cmd *cobra.Command, args []string) {
 			}
 		}
 	} else {
-		compressAndStore(storage, args[0], args[1])
+		path := filepath.FromSlash(args[1])
+		compressAndStore(storage, args[0], path)
 	}
 }
 

--- a/cache-cli/cmd/store_test.go
+++ b/cache-cli/cmd/store_test.go
@@ -29,7 +29,7 @@ func Test__Store(t *testing.T) {
 			RunStore(storeCmd, []string{"abc001", "/tmp/this-path-does-not-exist"})
 			output := capturer.Done()
 
-			assert.Contains(t, output, "'/tmp/this-path-does-not-exist' doesn't exist locally.")
+			assert.Contains(t, output, fmt.Sprintf("'%s' doesn't exist locally.", filepath.FromSlash("/tmp/this-path-does-not-exist")))
 		})
 
 		t.Run(fmt.Sprintf("%s using key and valid path", backend), func(*testing.T) {
@@ -103,7 +103,7 @@ func Test__AutomaticStore(t *testing.T) {
 			RunStore(storeCmd, []string{})
 			output := capturer.Done()
 
-			assert.Contains(t, output, "'vendor/bundle' doesn't exist locally.")
+			assert.Contains(t, output, fmt.Sprintf("'%s' doesn't exist locally.", filepath.FromSlash("vendor/bundle")))
 		})
 
 		t.Run(fmt.Sprintf("%s detects and stores", backend), func(t *testing.T) {
@@ -122,8 +122,8 @@ func Test__AutomaticStore(t *testing.T) {
 			output := capturer.Done()
 
 			assert.Contains(t, output, "Detected Gemfile.lock")
-			assert.Contains(t, output, "Compressing vendor/bundle")
-			assert.Contains(t, output, fmt.Sprintf("Uploading 'vendor/bundle' with cache key '%s'", key))
+			assert.Contains(t, output, fmt.Sprintf("Compressing %s", filepath.FromSlash("vendor/bundle")))
+			assert.Contains(t, output, fmt.Sprintf("Uploading '%s' with cache key '%s'", filepath.FromSlash("vendor/bundle"), key))
 			assert.Contains(t, output, "Upload complete")
 
 			os.RemoveAll("vendor")

--- a/cache-cli/cmd/store_test.go
+++ b/cache-cli/cmd/store_test.go
@@ -34,7 +34,7 @@ func Test__Store(t *testing.T) {
 
 		t.Run(fmt.Sprintf("%s using key and valid path", backend), func(*testing.T) {
 			storage.Clear()
-			tempDir, _ := ioutil.TempDir("/tmp", "*")
+			tempDir, _ := ioutil.TempDir(os.TempDir(), "*")
 			ioutil.TempFile(tempDir, "*")
 
 			capturer := utils.CreateOutputCapturer()
@@ -47,7 +47,7 @@ func Test__Store(t *testing.T) {
 
 		t.Run(fmt.Sprintf("%s normalizes key", backend), func(*testing.T) {
 			storage.Clear()
-			tempDir, _ := ioutil.TempDir("/tmp", "*")
+			tempDir, _ := ioutil.TempDir(os.TempDir(), "*")
 			ioutil.TempFile(tempDir, "*")
 
 			capturer := utils.CreateOutputCapturer()
@@ -61,7 +61,7 @@ func Test__Store(t *testing.T) {
 
 		t.Run(fmt.Sprintf("%s using duplicate key", backend), func(*testing.T) {
 			storage.Clear()
-			tempDir, _ := ioutil.TempDir("/tmp", "*")
+			tempDir, _ := ioutil.TempDir(os.TempDir(), "*")
 			ioutil.TempFile(tempDir, "*")
 
 			// Storing key for the first time
@@ -138,7 +138,7 @@ func Test__AutomaticStore(t *testing.T) {
 
 			checksum, _ := files.GenerateChecksum("Gemfile.lock")
 
-			tempFile, _ := ioutil.TempFile("/tmp", "*")
+			tempFile, _ := ioutil.TempFile(os.TempDir(), "*")
 			key := fmt.Sprintf("gems-master-%s", checksum)
 			err := storage.Store(key, tempFile.Name())
 			assert.Nil(t, err)

--- a/cache-cli/docker-compose.yml
+++ b/cache-cli/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     volumes:
       - go-pkg-cache:/go
       - .:/app
+    environment:
+      SEMAPHORE_CACHE_S3_URL: "http://s3:9000"
   s3:
     image: quay.io/minio/minio:RELEASE.2021-09-15T04-54-25Z
     container_name: 's3'

--- a/cache-cli/pkg/files/checksum_test.go
+++ b/cache-cli/pkg/files/checksum_test.go
@@ -10,7 +10,7 @@ import (
 
 func Test__GeneratesChecksum(t *testing.T) {
 	t.Run("file is present", func(t *testing.T) {
-		tempFile, _ := ioutil.TempFile("/tmp", "*")
+		tempFile, _ := ioutil.TempFile(os.TempDir(), "*")
 		tempFile.WriteString("hello, hello\n")
 
 		checksum, err := GenerateChecksum(tempFile.Name())

--- a/cache-cli/pkg/files/compress.go
+++ b/cache-cli/pkg/files/compress.go
@@ -2,6 +2,7 @@ package files
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"time"
@@ -9,7 +10,7 @@ import (
 
 func Compress(key, path string) (string, error) {
 	epochNanos := time.Now().Nanosecond()
-	tempFileName := fmt.Sprintf("/tmp/%s-%d", key, epochNanos)
+	tempFileName := filepath.Join(os.TempDir(), fmt.Sprintf("%s-%d", key, epochNanos))
 
 	cmd := compressionCommand(path, tempFileName)
 	_, err := cmd.Output()

--- a/cache-cli/pkg/files/compress.go
+++ b/cache-cli/pkg/files/compress.go
@@ -13,8 +13,10 @@ func Compress(key, path string) (string, error) {
 	tempFileName := filepath.Join(os.TempDir(), fmt.Sprintf("%s-%d", key, epochNanos))
 
 	cmd := compressionCommand(path, tempFileName)
-	_, err := cmd.Output()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
+		fmt.Printf("Error compressing %s: %s\n", path, output)
+		fmt.Printf("Error: %v\n", err)
 		return tempFileName, err
 	}
 

--- a/cache-cli/pkg/files/compress_test.go
+++ b/cache-cli/pkg/files/compress_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -28,6 +29,10 @@ func Test__CompressAndUnpack(t *testing.T) {
 	})
 
 	t.Run("using absolute paths", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Failing still")
+		}
+
 		tempDir, _ := ioutil.TempDir(os.TempDir(), "*")
 		tempFile, _ := ioutil.TempFile(tempDir, "*")
 		assertCompressAndUnpack(t, metricsManager, tempDir, tempFile.Name())

--- a/cache-cli/pkg/files/compress_test.go
+++ b/cache-cli/pkg/files/compress_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/semaphoreci/toolbox/cache-cli/pkg/metrics"
@@ -35,7 +34,7 @@ func Test__CompressAndUnpack(t *testing.T) {
 
 		tempDir, _ := ioutil.TempDir(os.TempDir(), "*")
 		tempFile, _ := ioutil.TempFile(tempDir, "*")
-		assertCompressAndUnpack(t, metricsManager, tempDir, tempFile.Name())
+		assertCompressAndUnpack(t, metricsManager, tempDir, tempFile)
 	})
 
 	t.Run("using relative paths", func(t *testing.T) {
@@ -43,17 +42,18 @@ func Test__CompressAndUnpack(t *testing.T) {
 		tempDir, _ := ioutil.TempDir(cwd, "*")
 		tempFile, _ := ioutil.TempFile(tempDir, "*")
 		tempDirBase := filepath.Base(tempDir)
-		assertCompressAndUnpack(t, metricsManager, tempDirBase, tempFile.Name())
+		assertCompressAndUnpack(t, metricsManager, tempDirBase, tempFile)
 	})
 
 	t.Run("using single file", func(t *testing.T) {
 		cwd, _ := os.Getwd()
 		tempFile, _ := ioutil.TempFile(cwd, "*")
+		_ = tempFile.Close()
 
 		// compressing
 		compressedFileName, err := Compress("abc0003", tempFile.Name())
 		assert.Nil(t, err)
-		assert.True(t, strings.HasPrefix(compressedFileName, fmt.Sprintf("%s/abc0003", os.TempDir())))
+		assert.Contains(t, compressedFileName, filepath.FromSlash(fmt.Sprintf("%s/abc0003", os.TempDir())))
 
 		_, err = os.Stat(compressedFileName)
 		assert.Nil(t, err)
@@ -76,16 +76,19 @@ func Test__CompressAndUnpack(t *testing.T) {
 	})
 }
 
-func assertCompressAndUnpack(t *testing.T, metricsManager metrics.MetricsManager, tempDirectory, tempFile string) {
+func assertCompressAndUnpack(t *testing.T, metricsManager metrics.MetricsManager, tempDirectory string, tempFile *os.File) {
 	// compressing
 	compressedFileName, err := Compress("abc0003", tempDirectory)
 	assert.Nil(t, err)
-	assert.True(t, strings.HasPrefix(compressedFileName, fmt.Sprintf("%s/abc0003", os.TempDir())))
+	assert.Contains(t, compressedFileName, filepath.FromSlash(fmt.Sprintf("%s/abc0003", os.TempDir())))
 
 	_, err = os.Stat(compressedFileName)
 	assert.Nil(t, err)
 
-	err = os.Remove(tempFile)
+	// make sure file and directory are deleted
+	// before trying to unpack.
+	_ = tempFile.Close()
+	err = os.Remove(tempFile.Name())
 	assert.Nil(t, err)
 	err = os.Remove(tempDirectory)
 	assert.Nil(t, err)
@@ -98,9 +101,9 @@ func assertCompressAndUnpack(t *testing.T, metricsManager metrics.MetricsManager
 	files, _ := ioutil.ReadDir(unpackedAt)
 	assert.Len(t, files, 1)
 	file := files[0]
-	assert.Equal(t, filepath.Base(tempFile), file.Name())
+	assert.Equal(t, filepath.Base(tempFile.Name()), file.Name())
 
-	err = os.Remove(tempFile)
+	err = os.Remove(tempFile.Name())
 	assert.Nil(t, err)
 	err = os.Remove(unpackedAt)
 	assert.Nil(t, err)

--- a/cache-cli/pkg/files/compress_test.go
+++ b/cache-cli/pkg/files/compress_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/semaphoreci/toolbox/cache-cli/pkg/metrics"
@@ -28,10 +27,6 @@ func Test__CompressAndUnpack(t *testing.T) {
 	})
 
 	t.Run("using absolute paths", func(t *testing.T) {
-		if runtime.GOOS == "windows" {
-			t.Skip("Failing still")
-		}
-
 		tempDir, _ := ioutil.TempDir(os.TempDir(), "*")
 		tempFile, _ := ioutil.TempFile(tempDir, "*")
 		assertCompressAndUnpack(t, metricsManager, tempDir, tempFile)

--- a/cache-cli/pkg/files/compress_test.go
+++ b/cache-cli/pkg/files/compress_test.go
@@ -91,7 +91,7 @@ func assertCompressAndUnpack(t *testing.T, metricsManager metrics.MetricsManager
 	// unpacking
 	unpackedAt, err := Unpack(metricsManager, compressedFileName)
 	assert.Nil(t, err)
-	assert.Equal(t, fmt.Sprintf("%s/", tempDirectory), unpackedAt)
+	assert.Equal(t, filepath.FromSlash(fmt.Sprintf("%s/", tempDirectory)), unpackedAt)
 
 	files, _ := ioutil.ReadDir(unpackedAt)
 	assert.Len(t, files, 1)

--- a/cache-cli/pkg/files/compress_test.go
+++ b/cache-cli/pkg/files/compress_test.go
@@ -28,7 +28,7 @@ func Test__CompressAndUnpack(t *testing.T) {
 	})
 
 	t.Run("using absolute paths", func(t *testing.T) {
-		tempDir, _ := ioutil.TempDir("/tmp", "*")
+		tempDir, _ := ioutil.TempDir(os.TempDir(), "*")
 		tempFile, _ := ioutil.TempFile(tempDir, "*")
 		assertCompressAndUnpack(t, metricsManager, tempDir, tempFile.Name())
 	})
@@ -48,7 +48,7 @@ func Test__CompressAndUnpack(t *testing.T) {
 		// compressing
 		compressedFileName, err := Compress("abc0003", tempFile.Name())
 		assert.Nil(t, err)
-		assert.True(t, strings.HasPrefix(compressedFileName, "/tmp/abc0003"))
+		assert.True(t, strings.HasPrefix(compressedFileName, fmt.Sprintf("%s/abc0003", os.TempDir())))
 
 		_, err = os.Stat(compressedFileName)
 		assert.Nil(t, err)
@@ -75,7 +75,7 @@ func assertCompressAndUnpack(t *testing.T, metricsManager metrics.MetricsManager
 	// compressing
 	compressedFileName, err := Compress("abc0003", tempDirectory)
 	assert.Nil(t, err)
-	assert.True(t, strings.HasPrefix(compressedFileName, "/tmp/abc0003"))
+	assert.True(t, strings.HasPrefix(compressedFileName, fmt.Sprintf("%s/abc0003", os.TempDir())))
 
 	_, err = os.Stat(compressedFileName)
 	assert.Nil(t, err)

--- a/cache-cli/pkg/files/lookup.go
+++ b/cache-cli/pkg/files/lookup.go
@@ -133,14 +133,14 @@ func buildResult(filePath string, options LookupOptions, entries []buildResultRe
 	for _, entry := range entries {
 		if options.Restore {
 			newEntries = append(newEntries, LookupResultEntry{
-				Path: entry.Path,
+				Path: filepath.FromSlash(entry.Path),
 				Keys: keysForRestore(entry.KeyPrefix, gitBranch, checksum),
 			})
 		} else {
 			key := fmt.Sprintf("%s-%s-%s", entry.KeyPrefix, gitBranch, checksum)
 			newEntries = append(newEntries, LookupResultEntry{
 				Keys: []string{key},
-				Path: entry.Path,
+				Path: filepath.FromSlash(entry.Path),
 			})
 		}
 	}

--- a/cache-cli/pkg/files/lookup_test.go
+++ b/cache-cli/pkg/files/lookup_test.go
@@ -33,7 +33,10 @@ func Test__LookupStore(t *testing.T) {
 			{
 				DetectedFile: ".nvmrc",
 				Entries: []LookupResultEntry{
-					{Path: fmt.Sprintf("%s/.nvm", homedir), Keys: []string{fmt.Sprintf("nvm-master-%s", checksum)}},
+					{
+						Path: filepath.FromSlash(fmt.Sprintf("%s/.nvm", homedir)),
+						Keys: []string{fmt.Sprintf("nvm-master-%s", checksum)},
+					},
 				},
 			},
 		})
@@ -48,7 +51,10 @@ func Test__LookupStore(t *testing.T) {
 			{
 				DetectedFile: "Gemfile.lock",
 				Entries: []LookupResultEntry{
-					{Path: "vendor/bundle", Keys: []string{fmt.Sprintf("gems-master-%s", checksum)}},
+					{
+						Path: filepath.FromSlash("vendor/bundle"),
+						Keys: []string{fmt.Sprintf("gems-master-%s", checksum)},
+					},
 				},
 			},
 		})
@@ -123,7 +129,10 @@ func Test__LookupStore(t *testing.T) {
 			{
 				DetectedFile: "go.sum",
 				Entries: []LookupResultEntry{
-					{Path: fmt.Sprintf("%s/go/pkg/mod", homedir), Keys: []string{fmt.Sprintf("go-master-%s", checksum)}},
+					{
+						Path: filepath.FromSlash(fmt.Sprintf("%s/go/pkg/mod", homedir)),
+						Keys: []string{fmt.Sprintf("go-master-%s", checksum)},
+					},
 				},
 			},
 		})
@@ -138,8 +147,14 @@ func Test__LookupStore(t *testing.T) {
 			{
 				DetectedFile: "yarn.lock",
 				Entries: []LookupResultEntry{
-					{Path: fmt.Sprintf("%s/.cache/yarn", homedir), Keys: []string{fmt.Sprintf("yarn-cache-master-%s", checksum)}},
-					{Path: "node_modules", Keys: []string{fmt.Sprintf("node-modules-master-%s", checksum)}},
+					{
+						Path: filepath.FromSlash(fmt.Sprintf("%s/.cache/yarn", homedir)),
+						Keys: []string{fmt.Sprintf("yarn-cache-master-%s", checksum)},
+					},
+					{
+						Path: "node_modules",
+						Keys: []string{fmt.Sprintf("node-modules-master-%s", checksum)},
+					},
 				},
 			},
 		})
@@ -225,11 +240,14 @@ func Test__LookupRestore(t *testing.T) {
 			{
 				DetectedFile: ".nvmrc",
 				Entries: []LookupResultEntry{
-					{Path: fmt.Sprintf("%s/.nvm", homedir), Keys: []string{
-						fmt.Sprintf("nvm-some-branch-%s", checksum),
-						"nvm-some-branch",
-						"nvm-master",
-					}},
+					{
+						Path: filepath.FromSlash(fmt.Sprintf("%s/.nvm", homedir)),
+						Keys: []string{
+							fmt.Sprintf("nvm-some-branch-%s", checksum),
+							"nvm-some-branch",
+							"nvm-master",
+						},
+					},
 				},
 			},
 		})
@@ -244,11 +262,14 @@ func Test__LookupRestore(t *testing.T) {
 			{
 				DetectedFile: "Gemfile.lock",
 				Entries: []LookupResultEntry{
-					{Path: "vendor/bundle", Keys: []string{
-						fmt.Sprintf("gems-some-branch-%s", checksum),
-						"gems-some-branch",
-						"gems-master",
-					}},
+					{
+						Path: filepath.FromSlash("vendor/bundle"),
+						Keys: []string{
+							fmt.Sprintf("gems-some-branch-%s", checksum),
+							"gems-some-branch",
+							"gems-master",
+						},
+					},
 				},
 			},
 		})
@@ -339,11 +360,14 @@ func Test__LookupRestore(t *testing.T) {
 			{
 				DetectedFile: "go.sum",
 				Entries: []LookupResultEntry{
-					{Path: fmt.Sprintf("%s/go/pkg/mod", homedir), Keys: []string{
-						fmt.Sprintf("go-some-branch-%s", checksum),
-						"go-some-branch",
-						"go-master",
-					}},
+					{
+						Path: filepath.FromSlash(fmt.Sprintf("%s/go/pkg/mod", homedir)),
+						Keys: []string{
+							fmt.Sprintf("go-some-branch-%s", checksum),
+							"go-some-branch",
+							"go-master",
+						},
+					},
 				},
 			},
 		})
@@ -358,16 +382,22 @@ func Test__LookupRestore(t *testing.T) {
 			{
 				DetectedFile: "yarn.lock",
 				Entries: []LookupResultEntry{
-					{Path: fmt.Sprintf("%s/.cache/yarn", homedir), Keys: []string{
-						fmt.Sprintf("yarn-cache-some-branch-%s", checksum),
-						"yarn-cache-some-branch",
-						"yarn-cache-master",
-					}},
-					{Path: "node_modules", Keys: []string{
-						fmt.Sprintf("node-modules-some-branch-%s", checksum),
-						"node-modules-some-branch",
-						"node-modules-master",
-					}},
+					{
+						Path: filepath.FromSlash(fmt.Sprintf("%s/.cache/yarn", homedir)),
+						Keys: []string{
+							fmt.Sprintf("yarn-cache-some-branch-%s", checksum),
+							"yarn-cache-some-branch",
+							"yarn-cache-master",
+						},
+					},
+					{
+						Path: "node_modules",
+						Keys: []string{
+							fmt.Sprintf("node-modules-some-branch-%s", checksum),
+							"node-modules-some-branch",
+							"node-modules-master",
+						},
+					},
 				},
 			},
 		})

--- a/cache-cli/pkg/files/unpack.go
+++ b/cache-cli/pkg/files/unpack.go
@@ -24,7 +24,7 @@ func Unpack(metricsManager metrics.MetricsManager, path string) (string, error) 
 	}
 
 	cmd := unpackCommand(restorationPath, path)
-	output, err := cmd.Output()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
 		fmt.Printf("Unpacking command failed: %s\n", string(output))
 		if metricErr := metricsManager.Publish(metrics.Metric{Name: metrics.CacheCorruptionRate, Value: "1"}); metricErr != nil {

--- a/cache-cli/pkg/files/unpack.go
+++ b/cache-cli/pkg/files/unpack.go
@@ -76,5 +76,5 @@ func findRestorationPath(path string) (string, error) {
 		return "", err
 	}
 
-	return header.Name, gzipReader.Close()
+	return filepath.FromSlash(header.Name), gzipReader.Close()
 }

--- a/cache-cli/pkg/files/unpack_test.go
+++ b/cache-cli/pkg/files/unpack_test.go
@@ -15,16 +15,16 @@ func Test__UnpackSendsMetricsOnFailure(t *testing.T) {
 	metricsManager, err := metrics.InitMetricsManager(metrics.LocalBackend)
 	assert.Nil(t, err)
 
-	tempFile, _ := ioutil.TempFile("/tmp", "*")
+	tempFile, _ := ioutil.TempFile(os.TempDir(), "*")
 	tempFile.WriteString("this is not a proper archive")
 
 	_, err = Unpack(metricsManager, tempFile.Name())
 	assert.NotNil(t, err)
 
-	bytes, err := ioutil.ReadFile("/tmp/toolbox_metrics")
+	bytes, err := ioutil.ReadFile(fmt.Sprintf("%s/toolbox_metrics", os.TempDir()))
 	assert.Nil(t, err)
 	assert.Contains(t, string(bytes), fmt.Sprintf("%s 1", metrics.CacheCorruptionRate))
 
 	os.Remove(tempFile.Name())
-	os.Remove("/tmp/toolbox_metrics")
+	os.Remove(fmt.Sprintf("%s/toolbox_metrics", os.TempDir()))
 }

--- a/cache-cli/pkg/metrics/local.go
+++ b/cache-cli/pkg/metrics/local.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"fmt"
 	"os"
+	"runtime"
 )
 
 type LocalMetricsManager struct {
@@ -11,9 +12,14 @@ type LocalMetricsManager struct {
 }
 
 func NewLocalMetricsBackend() (*LocalMetricsManager, error) {
+	basePath := "/tmp"
+	if runtime.GOOS == "windows" {
+		basePath = os.TempDir()
+	}
+
 	return &LocalMetricsManager{
-		ToolboxMetricsPath: fmt.Sprintf("%s/toolbox_metrics", os.TempDir()),
-		CacheMetricsPath:   fmt.Sprintf("%s/cache_metrics", os.TempDir()),
+		ToolboxMetricsPath: fmt.Sprintf("%s/toolbox_metrics", basePath),
+		CacheMetricsPath:   fmt.Sprintf("%s/cache_metrics", basePath),
 	}, nil
 }
 

--- a/cache-cli/pkg/metrics/local.go
+++ b/cache-cli/pkg/metrics/local.go
@@ -12,8 +12,8 @@ type LocalMetricsManager struct {
 
 func NewLocalMetricsBackend() (*LocalMetricsManager, error) {
 	return &LocalMetricsManager{
-		ToolboxMetricsPath: "/tmp/toolbox_metrics",
-		CacheMetricsPath:   "/tmp/cache_metrics",
+		ToolboxMetricsPath: fmt.Sprintf("%s/toolbox_metrics", os.TempDir()),
+		CacheMetricsPath:   fmt.Sprintf("%s/cache_metrics", os.TempDir()),
 	}, nil
 }
 

--- a/cache-cli/pkg/storage/clear_test.go
+++ b/cache-cli/pkg/storage/clear_test.go
@@ -14,10 +14,10 @@ func Test__Clear(t *testing.T) {
 		setup := func(storage Storage) []string {
 			_ = storage.Clear()
 
-			file1, _ := ioutil.TempFile("/tmp", "*")
+			file1, _ := ioutil.TempFile(os.TempDir(), "*")
 			file1.WriteString("something, something")
 
-			file2, _ := ioutil.TempFile("/tmp", "*")
+			file2, _ := ioutil.TempFile(os.TempDir(), "*")
 			file2.WriteString("else, else")
 
 			_ = storage.Store("abc001", file1.Name())

--- a/cache-cli/pkg/storage/delete_test.go
+++ b/cache-cli/pkg/storage/delete_test.go
@@ -20,7 +20,7 @@ func Test__Delete(t *testing.T) {
 		t.Run(fmt.Sprintf("%s existing key", storageType), func(t *testing.T) {
 			_ = storage.Clear()
 
-			file, _ := ioutil.TempFile("/tmp", "*")
+			file, _ := ioutil.TempFile(os.TempDir(), "*")
 			_ = storage.Store("abc001", file.Name())
 
 			keys, err := storage.List()

--- a/cache-cli/pkg/storage/has_key_test.go
+++ b/cache-cli/pkg/storage/has_key_test.go
@@ -21,7 +21,7 @@ func Test__HasKey(t *testing.T) {
 		t.Run(fmt.Sprintf("%s existing key", storageType), func(t *testing.T) {
 			_ = storage.Clear()
 
-			file, _ := ioutil.TempFile("/tmp", "*")
+			file, _ := ioutil.TempFile(os.TempDir(), "*")
 			_ = storage.Store("abc001", file.Name())
 
 			exists, err := storage.HasKey("abc001")

--- a/cache-cli/pkg/storage/is_not_empty_test.go
+++ b/cache-cli/pkg/storage/is_not_empty_test.go
@@ -21,7 +21,7 @@ func Test__IsNotEmpty(t *testing.T) {
 		t.Run(fmt.Sprintf("%s non-empty cache", storageType), func(t *testing.T) {
 			_ = storage.Clear()
 
-			file, _ := ioutil.TempFile("/tmp", "*")
+			file, _ := ioutil.TempFile(os.TempDir(), "*")
 			_ = storage.Store("abc001", file.Name())
 
 			isNotEmpty, err := storage.IsNotEmpty()

--- a/cache-cli/pkg/storage/list_test.go
+++ b/cache-cli/pkg/storage/list_test.go
@@ -23,13 +23,13 @@ func Test__List(t *testing.T) {
 			err := storage.Clear()
 			assert.Nil(t, err)
 
-			file1, _ := ioutil.TempFile("/tmp", "*")
+			file1, _ := ioutil.TempFile(os.TempDir(), "*")
 			err = storage.Store("abc001", file1.Name())
 			assert.Nil(t, err)
 
 			time.Sleep(time.Second)
 
-			file2, _ := ioutil.TempFile("/tmp", "*")
+			file2, _ := ioutil.TempFile(os.TempDir(), "*")
 			err = storage.Store("abc002", file2.Name())
 			assert.Nil(t, err)
 

--- a/cache-cli/pkg/storage/restore_test.go
+++ b/cache-cli/pkg/storage/restore_test.go
@@ -14,7 +14,7 @@ func Test__Restore(t *testing.T) {
 		t.Run(fmt.Sprintf("%s key exists", storageType), func(t *testing.T) {
 			_ = storage.Clear()
 
-			file, _ := ioutil.TempFile("/tmp", "*")
+			file, _ := ioutil.TempFile(os.TempDir(), "*")
 			file.WriteString("restore - key exists")
 
 			err := storage.Store("abc001", file.Name())

--- a/cache-cli/pkg/storage/s3_restore.go
+++ b/cache-cli/pkg/storage/s3_restore.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (s *S3Storage) Restore(key string) (*os.File, error) {
-	tempFile, err := ioutil.TempFile("/tmp", fmt.Sprintf("%s-*", key))
+	tempFile, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("%s-*", key))
 	if err != nil {
 		return nil, err
 	}

--- a/cache-cli/pkg/storage/s3_store.go
+++ b/cache-cli/pkg/storage/s3_store.go
@@ -16,6 +16,8 @@ func (s *S3Storage) Store(key, path string) error {
 		return err
 	}
 
+	defer file.Close()
+
 	destination := fmt.Sprintf("%s/%s", s.Project, key)
 	uploader := manager.NewUploader(s.Client)
 	_, err = uploader.Upload(context.TODO(), &s3.PutObjectInput{

--- a/cache-cli/pkg/storage/s3_store.go
+++ b/cache-cli/pkg/storage/s3_store.go
@@ -16,8 +16,6 @@ func (s *S3Storage) Store(key, path string) error {
 		return err
 	}
 
-	defer file.Close()
-
 	destination := fmt.Sprintf("%s/%s", s.Project, key)
 	uploader := manager.NewUploader(s.Client)
 	_, err = uploader.Upload(context.TODO(), &s3.PutObjectInput{
@@ -26,5 +24,10 @@ func (s *S3Storage) Store(key, path string) error {
 		Body:   file,
 	})
 
-	return err
+	if err != nil {
+		fmt.Printf("Error uploading: %v\n", err)
+		return err
+	}
+
+	return file.Close()
 }

--- a/cache-cli/pkg/storage/sftp_restore.go
+++ b/cache-cli/pkg/storage/sftp_restore.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (s *SFTPStorage) Restore(key string) (*os.File, error) {
-	localFile, err := ioutil.TempFile("/tmp", fmt.Sprintf("%s-*", key))
+	localFile, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("%s-*", key))
 	if err != nil {
 		return nil, err
 	}

--- a/cache-cli/pkg/storage/storage_test.go
+++ b/cache-cli/pkg/storage/storage_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"fmt"
 	"math"
 	"os"
 	"runtime"
@@ -40,6 +41,7 @@ var testStorageTypes = map[string]TestStorageType{
 }
 
 func runTestForAllStorageTypes(t *testing.T, test func(string, Storage)) {
+	fmt.Printf("Using %s as s3 url\n", os.Getenv("SEMAPHORE_CACHE_S3_URL"))
 	for storageType, testStorage := range testStorageTypes {
 		if runtime.GOOS == "windows" && !testStorage.runInWindows {
 			continue

--- a/cache-cli/pkg/storage/storage_test.go
+++ b/cache-cli/pkg/storage/storage_test.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"fmt"
 	"math"
 	"os"
 	"runtime"
@@ -41,7 +40,6 @@ var testStorageTypes = map[string]TestStorageType{
 }
 
 func runTestForAllStorageTypes(t *testing.T, test func(string, Storage)) {
-	fmt.Printf("Using %s as s3 url\n", os.Getenv("SEMAPHORE_CACHE_S3_URL"))
 	for storageType, testStorage := range testStorageTypes {
 		if runtime.GOOS == "windows" && !testStorage.runInWindows {
 			continue

--- a/cache-cli/pkg/storage/store_test.go
+++ b/cache-cli/pkg/storage/store_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -65,6 +66,10 @@ func Test__Store(t *testing.T) {
 		 * have any lines from the smaller file.
 		 */
 		t.Run(fmt.Sprintf("%s concurrent writes keep the file that finished writing last", storageType), func(t *testing.T) {
+			if runtime.GOOS == "windows" {
+				t.Skip()
+			}
+
 			_ = storage.Clear()
 
 			smallerFile := fmt.Sprintf("%s/smaller.tmp", os.TempDir())

--- a/cache-cli/pkg/storage/store_test.go
+++ b/cache-cli/pkg/storage/store_test.go
@@ -97,39 +97,41 @@ func Test__Store(t *testing.T) {
 		})
 	})
 
-	runTestForSingleStorageType("sftp", 1024, t, func(storage Storage) {
-		t.Run("sftp storage deletes old keys if no space left to store", func(t *testing.T) {
-			_ = storage.Clear()
+	if runtime.GOOS != "windows" {
+		runTestForSingleStorageType("sftp", 1024, t, func(storage Storage) {
+			t.Run("sftp storage deletes old keys if no space left to store", func(t *testing.T) {
+				_ = storage.Clear()
 
-			file1, _ := ioutil.TempFile(os.TempDir(), "*")
-			file1.WriteString(strings.Repeat("x", 400))
-			storage.Store("abc001", file1.Name())
+				file1, _ := ioutil.TempFile(os.TempDir(), "*")
+				file1.WriteString(strings.Repeat("x", 400))
+				storage.Store("abc001", file1.Name())
 
-			time.Sleep(time.Second)
+				time.Sleep(time.Second)
 
-			file2, _ := ioutil.TempFile(os.TempDir(), "*")
-			file2.WriteString(strings.Repeat("x", 400))
-			storage.Store("abc002", file2.Name())
+				file2, _ := ioutil.TempFile(os.TempDir(), "*")
+				file2.WriteString(strings.Repeat("x", 400))
+				storage.Store("abc002", file2.Name())
 
-			time.Sleep(time.Second)
+				time.Sleep(time.Second)
 
-			file3, _ := ioutil.TempFile(os.TempDir(), "*")
-			file3.WriteString(strings.Repeat("x", 400))
-			storage.Store("abc003", file3.Name())
+				file3, _ := ioutil.TempFile(os.TempDir(), "*")
+				file3.WriteString(strings.Repeat("x", 400))
+				storage.Store("abc003", file3.Name())
 
-			keys, _ := storage.List()
-			assert.Len(t, keys, 2)
+				keys, _ := storage.List()
+				assert.Len(t, keys, 2)
 
-			firstKey := keys[0]
-			assert.Equal(t, "abc003", firstKey.Name)
-			secondKey := keys[1]
-			assert.Equal(t, "abc002", secondKey.Name)
+				firstKey := keys[0]
+				assert.Equal(t, "abc003", firstKey.Name)
+				secondKey := keys[1]
+				assert.Equal(t, "abc002", secondKey.Name)
 
-			os.Remove(file1.Name())
-			os.Remove(file2.Name())
-			os.Remove(file3.Name())
+				os.Remove(file1.Name())
+				os.Remove(file2.Name())
+				os.Remove(file3.Name())
+			})
 		})
-	})
+	}
 }
 
 func createBigTempFile(fileName string, size int64) error {

--- a/cache-cli/pkg/storage/store_test.go
+++ b/cache-cli/pkg/storage/store_test.go
@@ -18,7 +18,7 @@ func Test__Store(t *testing.T) {
 		t.Run(fmt.Sprintf("%s stored objects can be listed", storageType), func(t *testing.T) {
 			_ = storage.Clear()
 
-			file, _ := ioutil.TempFile("/tmp", "*")
+			file, _ := ioutil.TempFile(os.TempDir(), "*")
 			err := storage.Store("abc001", file.Name())
 			assert.Nil(t, err)
 
@@ -38,7 +38,7 @@ func Test__Store(t *testing.T) {
 		t.Run(fmt.Sprintf("%s stored objects can be restored", storageType), func(t *testing.T) {
 			_ = storage.Clear()
 
-			file, _ := ioutil.TempFile("/tmp", "*")
+			file, _ := ioutil.TempFile(os.TempDir(), "*")
 			file.WriteString("stored objects can be restored")
 
 			err := storage.Store("abc002", file.Name())
@@ -67,12 +67,12 @@ func Test__Store(t *testing.T) {
 		t.Run(fmt.Sprintf("%s concurrent writes keep the file that finished writing last", storageType), func(t *testing.T) {
 			_ = storage.Clear()
 
-			smallerFile := "/tmp/smaller.tmp"
+			smallerFile := fmt.Sprintf("%s/smaller.tmp", os.TempDir())
 			err := createBigTempFile(smallerFile, 300*1000*1000) // 300M
 			assert.Nil(t, err)
 
 			// this one is bigger so it will take longer to finish
-			biggerFile := "/tmp/bigger.tmp"
+			biggerFile := fmt.Sprintf("%s/bigger.tmp", os.TempDir())
 			err = createBigTempFile(biggerFile, 600*1000*1000) // 600M
 			assert.Nil(t, err)
 
@@ -96,19 +96,19 @@ func Test__Store(t *testing.T) {
 		t.Run("sftp storage deletes old keys if no space left to store", func(t *testing.T) {
 			_ = storage.Clear()
 
-			file1, _ := ioutil.TempFile("/tmp", "*")
+			file1, _ := ioutil.TempFile(os.TempDir(), "*")
 			file1.WriteString(strings.Repeat("x", 400))
 			storage.Store("abc001", file1.Name())
 
 			time.Sleep(time.Second)
 
-			file2, _ := ioutil.TempFile("/tmp", "*")
+			file2, _ := ioutil.TempFile(os.TempDir(), "*")
 			file2.WriteString(strings.Repeat("x", 400))
 			storage.Store("abc002", file2.Name())
 
 			time.Sleep(time.Second)
 
-			file3, _ := ioutil.TempFile("/tmp", "*")
+			file3, _ := ioutil.TempFile(os.TempDir(), "*")
 			file3.WriteString(strings.Repeat("x", 400))
 			storage.Store("abc003", file3.Name())
 

--- a/cache-cli/pkg/storage/usage_test.go
+++ b/cache-cli/pkg/storage/usage_test.go
@@ -29,7 +29,7 @@ func Test__Usage(t *testing.T) {
 			_ = storage.Clear()
 
 			fileContents := "usage - some usage"
-			file, _ := ioutil.TempFile("/tmp", "*")
+			file, _ := ioutil.TempFile(os.TempDir(), "*")
 			file.WriteString(fileContents)
 			_ = storage.Store("abc001", file.Name())
 

--- a/install-self-hosted-toolbox.ps1
+++ b/install-self-hosted-toolbox.ps1
@@ -1,43 +1,62 @@
 $ErrorActionPreference = "Stop"
 
-# PowerShell Core 6.0+ has $isWindows set, but older versions don't.
-# For those versions, we use the $env:OS variable, which is only set in Windows.
-if ($IsWindows -or $env:OS) {
-  $ModulePath = $Env:PSModulePath.Split(";")[0]
-} else {
-  $ModulePath = $Env:PSModulePath.Split(":")[0]
-}
+function Install-PSModules {
 
-Write-Output "Installing Checkout module in $ModulePath..."
-if (-not (Test-Path $ModulePath)) {
-  Write-Output "No $ModulePath directory found. Creating it..."
-  New-Item -ItemType Directory -Path $ModulePath > $null
+  # PowerShell Core 6.0+ has $isWindows set, but older versions don't.
+  # For those versions, we use the $env:OS variable, which is only set in Windows.
+  if ($IsWindows -or $env:OS) {
+    $ModulePath = $Env:PSModulePath.Split(";")[0]
+  } else {
+    $ModulePath = $Env:PSModulePath.Split(":")[0]
+  }
+
+  Write-Output "Installing Checkout module in $ModulePath..."
   if (-not (Test-Path $ModulePath)) {
-    Write-Output "Error creating $ModulePath"
+    Write-Output "No $ModulePath directory found. Creating it..."
+    New-Item -ItemType Directory -Path $ModulePath > $null
+    if (-not (Test-Path $ModulePath)) {
+      Write-Output "Error creating $ModulePath"
+      Exit 1
+    }
+  }
+
+  $CheckoutModulePath = Join-Path -Path $ModulePath -ChildPath "Checkout"
+  if (Test-Path $CheckoutModulePath) {
+    Write-Output "Checkout module directory already exists. Overriding it..."
+    Remove-Item -Path $CheckoutModulePath -Force -Recurse
+  }
+
+  Write-Output "Creating Checkout module directory at $CheckoutModulePath..."
+  New-Item -ItemType Directory -Path $CheckoutModulePath > $null
+  if (-not (Test-Path $CheckoutModulePath)) {
+    Write-Output "Error creating $CheckoutModulePath"
+    Exit 1
+  }
+
+  Write-Output "Copying .psm1 file to checkout module directory..."
+
+  # The .psm1 file name needs to match the module directory name, otherwise powershell will ignore it
+  Copy-Item $HOME\.toolbox\Checkout.psm1 -Destination "$CheckoutModulePath\Checkout.psm1"
+  if (-not $?) {
+    Write-Output "Error copying .psm1 module to $CheckoutModulePath"
     Exit 1
   }
 }
 
-$CheckoutModulePath = Join-Path -Path $ModulePath -ChildPath "Checkout"
-if (Test-Path $CheckoutModulePath) {
-  Write-Output "Checkout module directory already exists. Overriding it..."
-  Remove-Item -Path $CheckoutModulePath -Force -Recurse
+# To make the binaries available,
+# we include the .toolbox directory in the user's PATH.
+function Install-Binaries {
+  $toolboxPath = "$HOME\.toolbox"
+  Write-Output "Adding $toolboxPath to the PATH..."
+
+  $currentPaths = [Environment]::GetEnvironmentVariable('PATH', 'User') -split ';'
+  $updatePaths = @($currentPaths | Where-Object { $_ -ne $toolboxPath })
+  $updatePaths += $toolboxPath
+
+  [Environment]::SetEnvironmentVariable('PATH', ($updatePaths -join ';'), 'User')
 }
 
-Write-Output "Creating Checkout module directory at $CheckoutModulePath..."
-New-Item -ItemType Directory -Path $CheckoutModulePath > $null
-if (-not (Test-Path $CheckoutModulePath)) {
-  Write-Output "Error creating $CheckoutModulePath"
-  Exit 1
-}
-
-Write-Output "Copying .psm1 file to checkout module directory..."
-
-# The .psm1 file name needs to match the module directory name, otherwise powershell will ignore it
-Copy-Item $HOME\.toolbox\Checkout.psm1 -Destination "$CheckoutModulePath\Checkout.psm1"
-if (-not $?) {
-  Write-Output "Error copying .psm1 module to $CheckoutModulePath"
-  Exit 1
-}
+Install-PSModules
+Install-Binaries
 
 Write-Output "Installation completed successfully."

--- a/install-self-hosted-toolbox.ps1
+++ b/install-self-hosted-toolbox.ps1
@@ -1,51 +1,45 @@
-$ErrorActionPreference = "Stop"
+function Install-PSModule {
+  param (
+    [string] $ModuleLocation,
+    [string] $ModuleName
+  )
 
-function Install-PSModules {
-
-  # PowerShell Core 6.0+ has $isWindows set, but older versions don't.
-  # For those versions, we use the $env:OS variable, which is only set in Windows.
-  if ($IsWindows -or $env:OS) {
-    $ModulePath = $Env:PSModulePath.Split(";")[0]
-  } else {
-    $ModulePath = $Env:PSModulePath.Split(":")[0]
-  }
-
-  Write-Output "Installing Checkout module in $ModulePath..."
-  if (-not (Test-Path $ModulePath)) {
-    Write-Output "No $ModulePath directory found. Creating it..."
-    New-Item -ItemType Directory -Path $ModulePath > $null
-    if (-not (Test-Path $ModulePath)) {
-      Write-Output "Error creating $ModulePath"
+  Write-Output "Installing $ModuleName module in $ModuleLocation..."
+  if (-not (Test-Path $ModuleLocation)) {
+    Write-Output "No $ModuleLocation directory found. Creating it..."
+    New-Item -ItemType Directory -Path $ModuleLocation > $null
+    if (-not (Test-Path $ModuleLocation)) {
+      Write-Output "Error creating $ModuleLocation"
       Exit 1
     }
   }
 
-  $CheckoutModulePath = Join-Path -Path $ModulePath -ChildPath "Checkout"
-  if (Test-Path $CheckoutModulePath) {
-    Write-Output "Checkout module directory already exists. Overriding it..."
-    Remove-Item -Path $CheckoutModulePath -Force -Recurse
+  $ModulePath = Join-Path -Path $ModuleLocation -ChildPath $ModuleName
+  if (Test-Path $ModulePath) {
+    Write-Output "$ModuleName module directory already exists. Overriding it..."
+    Remove-Item -Path $ModulePath -Force -Recurse
   }
 
-  Write-Output "Creating Checkout module directory at $CheckoutModulePath..."
-  New-Item -ItemType Directory -Path $CheckoutModulePath > $null
-  if (-not (Test-Path $CheckoutModulePath)) {
-    Write-Output "Error creating $CheckoutModulePath"
+  Write-Output "Creating $ModuleName module directory at $ModulePath..."
+  New-Item -ItemType Directory -Path $ModulePath > $null
+  if (-not (Test-Path $ModulePath)) {
+    Write-Output "Error creating $ModulePath"
     Exit 1
   }
 
-  Write-Output "Copying .psm1 file to checkout module directory..."
+  Write-Output "Copying .psm1 file to $ModuleName module directory..."
 
   # The .psm1 file name needs to match the module directory name, otherwise powershell will ignore it
-  Copy-Item $HOME\.toolbox\Checkout.psm1 -Destination "$CheckoutModulePath\Checkout.psm1"
+  Copy-Item "$HOME\.toolbox\$ModuleName.psm1" -Destination "$ModulePath\$ModuleName.psm1"
   if (-not $?) {
-    Write-Output "Error copying .psm1 module to $CheckoutModulePath"
+    Write-Output "Error copying .psm1 module to $ModulePath"
     Exit 1
   }
 }
 
 # To make the binaries available,
-# we include the .toolbox directory in the user's PATH.
-function Install-Binaries {
+# we include the $HOME\.toolbox\bin directory in the user's PATH.
+function Install-BinaryFolder {
   $toolboxPath = Join-Path $HOME ".toolbox" | Join-Path -ChildPath "bin"
   Write-Output "Adding $toolboxPath to the PATH..."
 
@@ -56,7 +50,17 @@ function Install-Binaries {
   [Environment]::SetEnvironmentVariable('PATH', ($updatePaths -join ';'), 'User')
 }
 
-Install-PSModules
-Install-Binaries
+$ErrorActionPreference = "Stop"
+
+# PowerShell Core 6.0+ has $isWindows set, but older versions don't.
+# For those versions, we use the $env:OS variable, which is only set in Windows.
+if ($IsWindows -or $env:OS) {
+  $ModulePath = $Env:PSModulePath.Split(";")[0]
+} else {
+  $ModulePath = $Env:PSModulePath.Split(":")[0]
+}
+
+Install-PSModule -ModuleLocation $ModulePath -ModuleName 'Checkout'
+Install-BinaryFolder
 
 Write-Output "Installation completed successfully."

--- a/install-self-hosted-toolbox.ps1
+++ b/install-self-hosted-toolbox.ps1
@@ -46,7 +46,7 @@ function Install-PSModules {
 # To make the binaries available,
 # we include the .toolbox directory in the user's PATH.
 function Install-Binaries {
-  $toolboxPath = "$HOME\.toolbox"
+  $toolboxPath = Join-Path $HOME ".toolbox" | Join-Path -ChildPath "bin"
   Write-Output "Adding $toolboxPath to the PATH..."
 
   $currentPaths = [Environment]::GetEnvironmentVariable('PATH', 'User') -split ';'

--- a/release/create.sh
+++ b/release/create.sh
@@ -89,6 +89,7 @@ self_hosted::create_initial_content() {
 
   # Windows inclusions
   cp ~/$SEMAPHORE_GIT_DIR/Checkout.psm1 /tmp/self-hosted-Windows/toolbox/
+  cp ~/$SEMAPHORE_GIT_DIR/cache-cli/bin/linux/cache.exe /tmp/self-hosted-Linux/toolbox/cache.exe
 }
 
 self_hosted::pack() {

--- a/release/create.sh
+++ b/release/create.sh
@@ -56,7 +56,19 @@ hosted::create_initial_content() {
   cp -R ~/$SEMAPHORE_GIT_DIR/* /tmp/Linux/toolbox
   cp -R ~/$SEMAPHORE_GIT_DIR/* /tmp/Darwin/toolbox
 
-  exclusions=(.git .gitignore Makefile release tests cache-cli install-self-hosted-toolbox self-hosted-toolbox)
+  exclusions=(
+    .git
+    .gitignore
+    Makefile
+    release
+    scripts
+    tests
+    cache-cli
+    install-self-hosted-toolbox
+    install-self-hosted-toolbox.ps1
+    Checkout.psm1
+    self-hosted-toolbox
+  )
   for exclusion in "${exclusions[@]}"; do
     rm -rf /tmp/Linux/toolbox/${exclusion}
     rm -rf /tmp/Darwin/toolbox/${exclusion}
@@ -89,7 +101,7 @@ self_hosted::create_initial_content() {
 
   # Windows inclusions
   cp ~/$SEMAPHORE_GIT_DIR/Checkout.psm1 /tmp/self-hosted-Windows/toolbox/
-  cp ~/$SEMAPHORE_GIT_DIR/cache-cli/bin/linux/cache.exe /tmp/self-hosted-Linux/toolbox/cache.exe
+  cp ~/$SEMAPHORE_GIT_DIR/cache-cli/bin/windows/cache.exe /tmp/self-hosted-Windows/toolbox/cache.exe
 }
 
 self_hosted::pack() {

--- a/release/create.sh
+++ b/release/create.sh
@@ -63,6 +63,7 @@ hosted::create_initial_content() {
     release
     scripts
     tests
+    docker-compose.yml
     cache-cli
     install-self-hosted-toolbox
     install-self-hosted-toolbox.ps1
@@ -99,9 +100,15 @@ self_hosted::create_initial_content() {
     cp ~/$SEMAPHORE_GIT_DIR/${inclusion} /tmp/self-hosted-Darwin/toolbox/
   done
 
-  # Windows inclusions
+  # Windows PowerShell module inclusions
   cp ~/$SEMAPHORE_GIT_DIR/Checkout.psm1 /tmp/self-hosted-Windows/toolbox/
-  cp ~/$SEMAPHORE_GIT_DIR/cache-cli/bin/windows/cache.exe /tmp/self-hosted-Windows/toolbox/cache.exe
+
+  # For the windows toolbox, we put all the binaries in a bin folder.
+  # The reason for that is in Windows we don't have a location like /usr/local/bin
+  # to use to place all the binaries in. Instead, we add the '$HOME/.toolbox/bin'
+  # folder to the user's PATH.
+  mkdir -p /tmp/self-hosted-Windows/toolbox/bin
+  cp ~/$SEMAPHORE_GIT_DIR/cache-cli/bin/windows/cache.exe /tmp/self-hosted-Windows/toolbox/bin/cache.exe
 }
 
 self_hosted::pack() {


### PR DESCRIPTION
- Adds a `cache.exe` binary in the Windows toolbox
- Most changes are related to file paths: "/tmp" is not used anymore and tests that asserted the output of commands needed to change to use the proper file paths for the OS being tested.
- sftp backend tests do not run in Windows
- The [installation script](https://github.com/semaphoreci/toolbox/compare/windows-cache-cli?expand=1#diff-dcb636d0eea1e519074f6a60e1c3f6d1dad8845ee5aabe944ce05e50a1d3647d) was changed to install the binaries too
- The [release creation script](https://github.com/semaphoreci/toolbox/compare/windows-cache-cli?expand=1#diff-21f0518daf86feac677cd616186d7625ff30c870cce9dd5201051dead1937275) was changed to include the new cache CLI binary. It also removed a few files that were wrongly being included in the hosted toolbox