### PR TITLE
fix: remove cache key from temporary file name

### DIFF
--- a/cache-cli/pkg/storage/sftp_store.go
+++ b/cache-cli/pkg/storage/sftp_store.go
@@ -7,8 +7,8 @@ import (
 )
 
 func (s *SFTPStorage) Store(key, path string) error {
-	epochNanos := time.Now().Nanosecond()
-	tmpKey := fmt.Sprintf("%s-%d", key, epochNanos)
+	epochNanos := time.Now().UnixNano()
+	tmpKey := fmt.Sprintf("%s-%d", os.Getenv("SEMAPHORE_JOB_ID"), epochNanos)
 
 	localFileInfo, err := os.Stat(path)
 	if err != nil {


### PR DESCRIPTION
Using the cache key entry as part of the temporary file name used during upload makes the temporary file visible to cache restores using the same key. That leads to incomplete files being restored.

This PR removes the cache key from the temporary file name to avoid such issues.