### PR TITLE
Revert "Release spc v1.9.3"

### DIFF
--- a/release/create.sh
+++ b/release/create.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 ARTIFACT_CLI_VERSION="v0.5.6"
 WHEN_CLI_VERSION="v1.0.5"
-SPC_CLI_VERSION="v1.9.3"
+SPC_CLI_VERSION="v1.9.2"
 TEST_RESULTS_CLI_VERSION="v0.6.2"
 
 ARTIFACT_CLI_URL="https://github.com/semaphoreci/artifact/releases/download/$ARTIFACT_CLI_VERSION"

--- a/tests/sem_version_container.bats
+++ b/tests/sem_version_container.bats
@@ -23,18 +23,16 @@ setup() {
 }
 
 
-@test "sem-version flutter 3.0.0" {
+@test "sem-version flutter 3.0.1" {
 
-  run sem-version flutter 3.0.0
+  run sem-version flutter 3.0.1
   assert_success
-  assert_line --partial "3.0.0"
+  assert_line --partial "3.0.1"
 }
 
 @test "sem-version flutter 3.0" {
 
   run sem-version flutter 3.0
   assert_success
-  assert_line --partial "3.0.0"
+  assert_line --partial "3.0.1"
 }
-
-


### PR DESCRIPTION
Reverts semaphoreci/toolbox#338

Customers reported errors with monorepo support for PRs to non-master branches.