### PR TITLE
fix: re-add artifact CLI in windows self-hosted toolbox

### DIFF
--- a/release/create.sh
+++ b/release/create.sh
@@ -44,6 +44,16 @@ include_external_darwin_binary() {
   cd ${destination_path} && tar -zxf ${binary_name}_Darwin.tar.gz && mv ${binary_name} toolbox/ && cd - > /dev/null
 }
 
+include_external_windows_binary() {
+  url=$1
+  binary_name=$2
+  destination_path=$3
+
+  echo "Downloading ${binary_name} for windows..."
+  curl -s -L --fail --retry 5 ${url}/${binary_name}_Windows_x86_64.tar.gz -o ${destination_path}/${binary_name}_Windows.tar.gz
+  cd ${destination_path} && tar -zxf ${binary_name}_Windows.tar.gz && mv ${binary_name}.exe toolbox/bin/ && cd - > /dev/null
+}
+
 hosted::create_initial_content() {
   echo "Creating initial content of the release directories for the hosted toolbox..."
 
@@ -116,6 +126,7 @@ self_hosted::pack() {
   self_hosted::create_initial_content
   include_external_linux_binary $ARTIFACT_CLI_URL "artifact" /tmp/self-hosted-Linux
   include_external_darwin_binary $ARTIFACT_CLI_URL "artifact" /tmp/self-hosted-Darwin
+  include_external_windows_binary $ARTIFACT_CLI_URL "artifact" /tmp/self-hosted-Windows
   include_external_linux_binary $TEST_RESULTS_CLI_URL "test-results" /tmp/self-hosted-Linux
   include_external_darwin_binary $TEST_RESULTS_CLI_URL "test-results" /tmp/self-hosted-Darwin
   include_external_linux_binary $SPC_CLI_URL "spc" /tmp/self-hosted-Linux


### PR DESCRIPTION
During one of the artifact CLI version rollbacks, we removed it from the self-hosted Windows toolbox. See: https://github.com/semaphoreci/toolbox/pull/331.

Since then, we have updated the artifact CLI version again but forgot to re-include the artifact CLI in the self-hosted Windows toolbox.