### PR TITLE
feat: create self-hosted ARM toolbox

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -20,11 +20,15 @@ blocks:
             - "export PATH=/home/semaphore/go/bin:$PATH"
             - checkout
             - cd cache-cli
-            - make build.linux
-            - make build.darwin
+            - make build.linux ARCH=amd64
+            - make build.linux ARCH=arm64
+            - make build.darwin ARCH=amd64
+            - make build.darwin ARCH=arm64
             - make build.windows
-            - artifact push workflow bin/linux/cache -d bin/linux/cache
-            - artifact push workflow bin/darwin/cache -d bin/darwin/cache
+            - artifact push workflow bin/linux/amd64/cache -d bin/linux/amd64/cache
+            - artifact push workflow bin/linux/arm64/cache -d bin/linux/arm64/cache
+            - artifact push workflow bin/darwin/amd64/cache -d bin/darwin/amd64/cache
+            - artifact push workflow bin/darwin/arm64/cache -d bin/darwin/arm64/cache
             - artifact push workflow bin/windows/cache.exe -d bin/windows/cache.exe
         - name: Build sem-context CLI
           commands:
@@ -81,8 +85,8 @@ blocks:
       prologue:
         commands:
           - checkout
-          - artifact pull workflow bin/linux/cache -d cache-cli/bin/linux/cache
-          - artifact pull workflow bin/darwin/cache -d cache-cli/bin/darwin/cache
+          - artifact pull workflow bin/linux/amd64/cache -d cache-cli/bin/linux/amd64/cache
+          - artifact pull workflow bin/darwin/amd64/cache -d cache-cli/bin/darwin/amd64/cache
           - artifact pull workflow bin/darwin/sem-context -d sem-context/bin/darwin/sem-context
           - artifact pull workflow bin/linux/sem-context -d sem-context/bin/linux/sem-context
           - bash release/create.sh
@@ -123,8 +127,8 @@ blocks:
           - checkout
           - sudo apt-get update 
           - sudo apt-get install -y libargon2-0
-          - artifact pull workflow bin/linux/cache -d cache-cli/bin/linux/cache
-          - artifact pull workflow bin/darwin/cache -d cache-cli/bin/darwin/cache
+          - artifact pull workflow bin/linux/amd64/cache -d cache-cli/bin/linux/amd64/cache
+          - artifact pull workflow bin/darwin/amd64/cache -d cache-cli/bin/darwin/amd64/cache
           - artifact pull workflow bin/darwin/sem-context -d sem-context/bin/darwin/sem-context
           - artifact pull workflow bin/linux/sem-context -d sem-context/bin/linux/sem-context
           - bash release/create.sh
@@ -156,8 +160,8 @@ blocks:
       prologue:
         commands:
           - checkout
-          - artifact pull workflow bin/linux/cache -d cache-cli/bin/linux/cache
-          - artifact pull workflow bin/darwin/cache -d cache-cli/bin/darwin/cache
+          - artifact pull workflow bin/linux/amd64/cache -d cache-cli/bin/linux/amd64/cache
+          - artifact pull workflow bin/darwin/amd64/cache -d cache-cli/bin/darwin/amd64/cache
           - artifact pull workflow bin/darwin/sem-context -d sem-context/bin/darwin/sem-context
           - artifact pull workflow bin/linux/sem-context -d sem-context/bin/linux/sem-context
           - bash release/create.sh
@@ -177,8 +181,8 @@ blocks:
       prologue:
         commands:
           - checkout
-          - artifact pull workflow bin/linux/cache -d cache-cli/bin/linux/cache
-          - artifact pull workflow bin/darwin/cache -d cache-cli/bin/darwin/cache
+          - artifact pull workflow bin/linux/amd64/cache -d cache-cli/bin/linux/amd64/cache
+          - artifact pull workflow bin/darwin/amd64/cache -d cache-cli/bin/darwin/amd64/cache
           - artifact pull workflow bin/darwin/sem-context -d sem-context/bin/darwin/sem-context
           - artifact pull workflow bin/linux/sem-context -d sem-context/bin/linux/sem-context
           - bash release/create.sh
@@ -215,8 +219,8 @@ blocks:
       prologue:
         commands:
           - checkout
-          - artifact pull workflow bin/linux/cache -d cache-cli/bin/linux/cache
-          - artifact pull workflow bin/darwin/cache -d cache-cli/bin/darwin/cache
+          - artifact pull workflow bin/linux/amd64/cache -d cache-cli/bin/linux/amd64/cache
+          - artifact pull workflow bin/darwin/amd64/cache -d cache-cli/bin/darwin/amd64/cache
           - artifact pull workflow bin/darwin/sem-context -d sem-context/bin/darwin/sem-context
           - artifact pull workflow bin/linux/sem-context -d sem-context/bin/linux/sem-context
           - bash release/create.sh
@@ -258,8 +262,8 @@ blocks:
       prologue:
         commands:
           - checkout
-          - artifact pull workflow bin/linux/cache -d cache-cli/bin/linux/cache
-          - artifact pull workflow bin/darwin/cache -d cache-cli/bin/darwin/cache
+          - artifact pull workflow bin/linux/amd64/cache -d cache-cli/bin/linux/amd64/cache
+          - artifact pull workflow bin/darwin/amd64/cache -d cache-cli/bin/darwin/amd64/cache
           - artifact pull workflow bin/linux/sem-context -d sem-context/bin/linux/sem-context
           - artifact pull workflow bin/darwin/sem-context -d sem-context/bin/darwin/sem-context
           - bash release/create.sh
@@ -297,8 +301,8 @@ blocks:
       prologue:
         commands:
           - checkout
-          - artifact pull workflow bin/linux/cache -d cache-cli/bin/linux/cache
-          - artifact pull workflow bin/darwin/cache -d cache-cli/bin/darwin/cache
+          - artifact pull workflow bin/linux/amd64/cache -d cache-cli/bin/linux/amd64/cache
+          - artifact pull workflow bin/darwin/amd64/cache -d cache-cli/bin/darwin/amd64/cache
           - artifact pull workflow bin/linux/sem-context -d sem-context/bin/linux/sem-context
           - artifact pull workflow bin/darwin/sem-context -d sem-context/bin/darwin/sem-context
           - bash release/create.sh
@@ -330,8 +334,8 @@ blocks:
       prologue:
         commands:
           - checkout
-          - artifact pull workflow bin/linux/cache -d cache-cli/bin/linux/cache
-          - artifact pull workflow bin/darwin/cache -d cache-cli/bin/darwin/cache
+          - artifact pull workflow bin/linux/amd64/cache -d cache-cli/bin/linux/amd64/cache
+          - artifact pull workflow bin/darwin/amd64/cache -d cache-cli/bin/darwin/amd64/cache
           - artifact pull workflow bin/linux/sem-context -d sem-context/bin/linux/sem-context
           - artifact pull workflow bin/darwin/sem-context -d sem-context/bin/darwin/sem-context
           - bash release/create.sh
@@ -432,8 +436,8 @@ blocks:
       prologue:
         commands:
           - checkout
-          - artifact pull workflow bin/linux/cache -d cache-cli/bin/linux/cache
-          - artifact pull workflow bin/darwin/cache -d cache-cli/bin/darwin/cache
+          - artifact pull workflow bin/linux/amd64/cache -d cache-cli/bin/linux/amd64/cache
+          - artifact pull workflow bin/darwin/amd64/cache -d cache-cli/bin/darwin/amd64/cache
           - artifact pull workflow bin/linux/sem-context -d sem-context/bin/linux/sem-context
           - artifact pull workflow bin/darwin/sem-context -d sem-context/bin/darwin/sem-context
           - bash release/create.sh
@@ -463,8 +467,8 @@ blocks:
       prologue:
         commands:
           - checkout
-          - artifact pull workflow bin/linux/cache -d cache-cli/bin/linux/cache
-          - artifact pull workflow bin/darwin/cache -d cache-cli/bin/darwin/cache
+          - artifact pull workflow bin/linux/amd64/cache -d cache-cli/bin/linux/amd64/cache
+          - artifact pull workflow bin/darwin/amd64/cache -d cache-cli/bin/darwin/amd64/cache
           - artifact pull workflow bin/linux/sem-context -d sem-context/bin/linux/sem-context
           - artifact pull workflow bin/darwin/sem-context -d sem-context/bin/darwin/sem-context
           - bash release/create.sh

--- a/cache-cli/Makefile
+++ b/cache-cli/Makefile
@@ -30,10 +30,10 @@ test.watch:
 	docker-compose run --rm cli gotestsum --watch --format short-verbose --junitfile junit-report.xml --packages="./..." -- -p 1
 
 build.darwin:
-	CGO_ENABLED=0 GOOS=darwin go build -o bin/darwin/cache main.go
+	CGO_ENABLED=0 GOOS=darwin GOARCH=$(ARCH) go build -o bin/darwin/$(ARCH)/cache main.go
 
 build.linux:
-	CGO_ENABLED=0 GOOS=linux go build -o bin/linux/cache main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -o bin/linux/$(ARCH)/cache main.go
 
 build.windows:
 	CGO_ENABLED=0 GOOS=windows go build -o bin/windows/cache.exe main.go

--- a/release/create.sh
+++ b/release/create.sh
@@ -200,6 +200,8 @@ create_tarball "darwin.tar" /tmp/Darwin
 if [[ $create_self_hosted == "true" ]]; then
   self_hosted::pack
   create_tarball "linux.tar" /tmp/self-hosted-Linux
+  create_tarball "linux-arm.tar" /tmp/self-hosted-Linux-arm
   create_tarball "darwin.tar" /tmp/self-hosted-Darwin
+  create_tarball "darwin-arm.tar" /tmp/self-hosted-Darwin-arm
   create_tarball "windows.tar" /tmp/self-hosted-Windows
 fi

--- a/release/upload.sh
+++ b/release/upload.sh
@@ -10,7 +10,9 @@ set -euo pipefail
 #      - /tmp/Linux/linux.tar
 #      - /tmp/Darwin/darwin.tar
 #      - /tmp/self-hosted-Linux/linux.tar
+#      - /tmp/self-hosted-Linux-arm/linux-arm.tar
 #      - /tmp/self-hosted-Darwin/darwin.tar
+#      - /tmp/self-hosted-Darwin-arm/darwin-arm.tar
 #
 #   2. Upload the tarballs to Github by running release/upload.sh.
 #
@@ -50,6 +52,16 @@ curl \
     -X POST \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.v3+json" \
+    -H "Content-Type: $(file -b --mime-type /tmp/self-hosted-Linux/linux.tar)" \
+    --data-binary @/tmp/self-hosted-Linux-arm/linux-arm.tar \
+    "https://uploads.github.com/repos/semaphoreci/toolbox/releases/$release_id/assets?name=self-hosted-linux-arm.tar"
+
+echo "self-hosted-linux-arm.tar uploaded"
+
+curl \
+    -X POST \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github.v3+json" \
     -H "Content-Type: $(file -b --mime-type /tmp/Darwin/darwin.tar)" \
     --data-binary @/tmp/Darwin/darwin.tar \
     "https://uploads.github.com/repos/semaphoreci/toolbox/releases/$release_id/assets?name=darwin.tar"
@@ -65,6 +77,16 @@ curl \
     "https://uploads.github.com/repos/semaphoreci/toolbox/releases/$release_id/assets?name=self-hosted-darwin.tar"
 
 echo "self-hosted-darwin.tar uploaded"
+
+curl \
+    -X POST \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github.v3+json" \
+    -H "Content-Type: $(file -b --mime-type /tmp/self-hosted-Darwin/darwin.tar)" \
+    --data-binary @/tmp/self-hosted-Darwin-arm/darwin-arm.tar \
+    "https://uploads.github.com/repos/semaphoreci/toolbox/releases/$release_id/assets?name=self-hosted-darwin-arm.tar"
+
+echo "self-hosted-darwin-arm.tar uploaded"
 
 curl \
     -X POST \


### PR DESCRIPTION
- Updates cache-cli to build for `amd64` and `arm64`.
- Updates `release/create.sh` script to create tarballs for amd64 and arm64, for Linux and Darwin.
- Updates `release/upload.sh` to upload the new ARM tarballs.