### PR TITLE
fix: release promotion

### DIFF
--- a/.semaphore/release.yml
+++ b/.semaphore/release.yml
@@ -14,8 +14,10 @@ blocks:
           commands:
             - export GITHUB_TOKEN=$ACCESS_TOKEN
             - checkout
-            - artifact pull workflow bin/linux/cache -d cache-cli/bin/linux/cache
-            - artifact pull workflow bin/darwin/cache -d cache-cli/bin/darwin/cache
+            - artifact push workflow bin/linux/amd64/cache -d bin/linux/amd64/cache
+            - artifact push workflow bin/linux/arm64/cache -d bin/linux/arm64/cache
+            - artifact push workflow bin/darwin/amd64/cache -d bin/darwin/amd64/cache
+            - artifact push workflow bin/darwin/arm64/cache -d bin/darwin/arm64/cache
             - artifact pull workflow bin/windows/cache.exe -d cache-cli/bin/windows/cache.exe
             - artifact pull workflow bin/linux/sem-context -d sem-context/bin/linux/sem-context
             - artifact pull workflow bin/darwin/sem-context -d sem-context/bin/darwin/sem-context

--- a/.semaphore/release.yml
+++ b/.semaphore/release.yml
@@ -14,10 +14,10 @@ blocks:
           commands:
             - export GITHUB_TOKEN=$ACCESS_TOKEN
             - checkout
-            - artifact pull workflow bin/linux/amd64/cache -d bin/linux/amd64/cache
-            - artifact pull workflow bin/linux/arm64/cache -d bin/linux/arm64/cache
-            - artifact pull workflow bin/darwin/amd64/cache -d bin/darwin/amd64/cache
-            - artifact pull workflow bin/darwin/arm64/cache -d bin/darwin/arm64/cache
+            - artifact pull workflow bin/linux/amd64/cache -d cache-cli/bin/linux/amd64/cache
+            - artifact pull workflow bin/linux/arm64/cache -d cache-cli/bin/linux/arm64/cache
+            - artifact pull workflow bin/darwin/amd64/cache -d cache-cli/bin/darwin/amd64/cache
+            - artifact pull workflow bin/darwin/arm64/cache -d cache-cli/bin/darwin/arm64/cache
             - artifact pull workflow bin/windows/cache.exe -d cache-cli/bin/windows/cache.exe
             - artifact pull workflow bin/linux/sem-context -d sem-context/bin/linux/sem-context
             - artifact pull workflow bin/darwin/sem-context -d sem-context/bin/darwin/sem-context

--- a/.semaphore/release.yml
+++ b/.semaphore/release.yml
@@ -14,10 +14,10 @@ blocks:
           commands:
             - export GITHUB_TOKEN=$ACCESS_TOKEN
             - checkout
-            - artifact push workflow bin/linux/amd64/cache -d bin/linux/amd64/cache
-            - artifact push workflow bin/linux/arm64/cache -d bin/linux/arm64/cache
-            - artifact push workflow bin/darwin/amd64/cache -d bin/darwin/amd64/cache
-            - artifact push workflow bin/darwin/arm64/cache -d bin/darwin/arm64/cache
+            - artifact pull workflow bin/linux/amd64/cache -d bin/linux/amd64/cache
+            - artifact pull workflow bin/linux/arm64/cache -d bin/linux/arm64/cache
+            - artifact pull workflow bin/darwin/amd64/cache -d bin/darwin/amd64/cache
+            - artifact pull workflow bin/darwin/arm64/cache -d bin/darwin/arm64/cache
             - artifact pull workflow bin/windows/cache.exe -d cache-cli/bin/windows/cache.exe
             - artifact pull workflow bin/linux/sem-context -d sem-context/bin/linux/sem-context
             - artifact pull workflow bin/darwin/sem-context -d sem-context/bin/darwin/sem-context


### PR DESCRIPTION
https://github.com/semaphoreci/toolbox/pull/367 changed the artifact names for the cache CLI. This pulls them from the right place.