### PR TITLE
sem-version ruby: Support "3.2" as alias for 3.2.0

### DIFF
--- a/sem-version
+++ b/sem-version
@@ -46,6 +46,7 @@ version::change_ruby() {
   [[ "$software_version" == "2.7" ]] && software_version="2.7.7"
   [[ "$software_version" == "3.0" ]] && software_version="3.0.5"
   [[ "$software_version" == "3.1" ]] && software_version="3.1.3"
+  [[ "$software_version" == "3.2" ]] && software_version="3.2.0"
 
   if ! [ -d ~/.rbenv/versions/"${software_version}" ]; then
     sem-install ruby "${software_version}"

--- a/tests/sem_version_bionic/ruby.bats
+++ b/tests/sem_version_bionic/ruby.bats
@@ -86,6 +86,11 @@ setup() {
   assert_success
   run ruby --version
   assert_line --partial "ruby 3.1.3"
+
+  run sem-version ruby 3.2
+  assert_success
+  run ruby --version
+  assert_line --partial "ruby 3.2.0"
 }
 
 @test "change ruby to 4.0.1" {


### PR DESCRIPTION
For older versions of Ruby, we can specify an X.Y version and it will automatically be expanded to use the latest X.Y.Z patch level that rbenv requires. For example `sem-version ruby 3.0` gets expanded to `sem-version ruby 3.0.5`.

However, this doesn't work for 3.2.

This PR adds support for expanding 3.2 to 3.2.0.