### PR TITLE
fix: create parent directory if not in archive

### DIFF
--- a/cache-cli/pkg/archive/archiver_test.go
+++ b/cache-cli/pkg/archive/archiver_test.go
@@ -218,6 +218,7 @@ func Test__Compress(t *testing.T) {
 			cwd, _ := os.Getwd()
 			tempDir, _ := ioutil.TempDir(cwd, "*")
 			tempFile, _ := ioutil.TempFile(tempDir, "*")
+			_ = tempFile.Close()
 
 			// compressing
 			compressedFileName := tmpFileNameWithPrefix("abc0007")

--- a/cache-cli/pkg/archive/shell_out_archiver.go
+++ b/cache-cli/pkg/archive/shell_out_archiver.go
@@ -52,7 +52,7 @@ func (a *ShellOutArchiver) Decompress(src string) (string, error) {
 			log.Errorf("Error publishing %s metric: %v", metrics.CacheCorruptionRate, metricErr)
 		}
 
-		return "", fmt.Errorf("error execution decompressio command: %s, %v", string(output), err)
+		return "", fmt.Errorf("error executing decompression command: %s, %v", string(output), err)
 	}
 
 	return restorationPath, nil


### PR DESCRIPTION
Sometimes the file is inside a directory, which is not in the archive. We handle that case by handling the `os.ErrNotExist` error when opening the file. If that happens, we create the parent directories, and try to open the file again.