### PR TITLE
libcheckout: Fail if branch is missing but sha exist on a different branch

### DIFF
--- a/libcheckout
+++ b/libcheckout
@@ -165,6 +165,14 @@ function checkout::checkrevision {
   fi
 }
 
+function checkout::branch_checkout {
+  git checkout -f "$SEMAPHORE_GIT_BRANCH"
+  if [ $? -ne 0 ]; then
+    echo "Branch: ${SEMAPHORE_GIT_BRANCH} not found .... Exiting"
+    return 1
+  fi
+}
+
 function checkout::shallow() {
   if [ -z ${SEMAPHORE_GIT_DEPTH:-""} ]; then
     SEMAPHORE_GIT_DEPTH=50
@@ -174,7 +182,11 @@ function checkout::shallow() {
   if [ $? -ne 0 ]; then
     echo "Branch not found performing full clone"
     git clone $SEMAPHORE_GIT_URL $SEMAPHORE_GIT_DIR
-    cd $SEMAPHORE_GIT_DIR
+    cd "$SEMAPHORE_GIT_DIR"
+    checkout::branch_checkout
+    if [ $? -ne 0 ]; then
+      return 1
+    fi
     checkout::checkrevision
     if [ "$?" -eq "0" ]; then
       git reset --hard $SEMAPHORE_GIT_SHA 2>/dev/null

--- a/tests/libcheckout.bats
+++ b/tests/libcheckout.bats
@@ -45,6 +45,7 @@ teardown() {
 
   run checkout
   assert_failure
+  assert_output --partial "Revision: $SEMAPHORE_GIT_SHA not found .... Exiting"
 }
 
 @test "libcheckout - [Push] missing branch and sha" {
@@ -54,6 +55,7 @@ teardown() {
 
   run checkout
   assert_failure
+  assert_output --partial "Branch: $SEMAPHORE_GIT_BRANCH not found .... Exiting"
 }
 
 @test "libcheckout - [Push] missing branch, sha exist on different branch" {
@@ -62,7 +64,8 @@ teardown() {
   export SEMAPHORE_GIT_SHA=91940c2cc18ec08b751482f806f1b8bfa03d98a5
 
   run checkout
-  assert_success
+  assert_failure
+  assert_output --partial "Branch: $SEMAPHORE_GIT_BRANCH not found .... Exiting"
 }
 
 # Tag
@@ -244,7 +247,7 @@ teardown() {
 @test "libcheckout - Checkout and use cache" {
 
   export SEMAPHORE_GIT_URL="https://github.com/rails/rails.git"
-  export SEMAPHORE_GIT_BRANCH=master
+  export SEMAPHORE_GIT_BRANCH=main
   export SEMAPHORE_GIT_DIR=rails
   export SEMAPHORE_GIT_SHA=f907b418aecfb6dab4e30149b88a8593ddd321b9
   cache clear

--- a/tests/libcheckout.bats
+++ b/tests/libcheckout.bats
@@ -17,7 +17,7 @@ setup() {
   export SEMAPHORE_GIT_SHA=5608567
   export SEMAPHORE_GIT_REPO_SLUG="mojombo/grit"
   export SEMAPHORE_GIT_REF="refs/heads/master"
-  
+
   set -u
   source ~/.toolbox/libcheckout
   rm -rf $SEMAPHORE_GIT_DIR
@@ -47,8 +47,18 @@ teardown() {
   assert_failure
 }
 
-@test "libcheckout - [Push] missing branch" {
+@test "libcheckout - [Push] missing branch and sha" {
   export SEMAPHORE_GIT_REF_TYPE="push"
+  export SEMAPHORE_GIT_BRANCH="non-existing-branch"
+  export SEMAPHORE_GIT_SHA=91940c2cc18ec08b751482f806f1b8bfa03d98a4
+
+  run checkout
+  assert_failure
+}
+
+@test "libcheckout - [Push] missing branch, sha exist on different branch" {
+  export SEMAPHORE_GIT_REF_TYPE="push"
+  export SEMAPHORE_GIT_BRANCH="non-existing-branch"
   export SEMAPHORE_GIT_SHA=91940c2cc18ec08b751482f806f1b8bfa03d98a5
 
   run checkout


### PR DESCRIPTION
This fixes the following scenario:

1. there is a branch `a` and commit `sha-1`
2. create branch `b` from the top of branch `a` so it contains commit `sha-1`
3. workflow is started for branch `b`
4. branch `b` is deleted
5. `checkout` command within the workflow is run in a shallow mode and the branch checkout fails since the branch `b` is not found
6. as a failover, checkout uses a full clone of the repo which sets up `master/main` as a working branch
7. checkout tries to switch to the targeted commit `sha-1` with `git reset --hard`
8. since that commit is present on branch `a` this will succeed but **the active branch will remain`master/main`**

As a fix, I introduced an additional step between 6) and 7) that tries to checkout the actual branch (branch `b` in the example) and fails if the branch is not present.