### PR TITLE
fix: add error metric for checkout

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -66,7 +66,7 @@ blocks:
             - 'shellcheck sem-service -f gcc | wc -l && [[ "$(shellcheck sem-service -f gcc | wc -l)" -le 76 ]]'
             - 'shellcheck sem-version -f gcc | wc -l && [[ "$(shellcheck sem-version -f gcc | wc -l)" -le 21 ]]'
             - 'shellcheck cache       -f gcc | wc -l && [[ "$(shellcheck cache -f gcc | wc -l)" -le 152 ]]'
-            - 'shellcheck libcheckout -f gcc | wc -l && [[ "$(shellcheck libcheckout -f gcc | wc -l)" -le 86 ]]'
+            - 'shellcheck libcheckout -f gcc | wc -l && [[ "$(shellcheck libcheckout -f gcc | wc -l)" -le 90 ]]'
             - shellcheck install-package
             - shellcheck sem-semantic-release
         - name: PowerShell check

--- a/libcheckout
+++ b/libcheckout
@@ -185,12 +185,15 @@ function checkout::shallow() {
     cd "$SEMAPHORE_GIT_DIR"
     checkout::branch_checkout
     if [ $? -ne 0 ]; then
+      checkout::error_metric
       return 1
     fi
+
     checkout::checkrevision
     if [ "$?" -eq "0" ]; then
       git reset --hard $SEMAPHORE_GIT_SHA 2>/dev/null
     else
+      checkout::error_metric
       return 1
     fi
   else
@@ -203,6 +206,7 @@ function checkout::shallow() {
       if [ "$?" -eq "0" ]; then
         git reset --hard $SEMAPHORE_GIT_SHA 2>/dev/null
       else
+        checkout::error_metric
         return 1
       fi
     fi
@@ -222,7 +226,7 @@ function checkout::refbased() {
     retry git fetch origin +$SEMAPHORE_GIT_REF: 2>/dev/null
     if [ $? -ne 0 ]; then
       echo "Revision: ${SEMAPHORE_GIT_SHA} not found .... Exiting"
-
+      checkout::error_metric
       return 1
     else
       git checkout -qf FETCH_HEAD
@@ -236,7 +240,7 @@ function checkout::refbased() {
     retry git clone --depth $SEMAPHORE_GIT_DEPTH -b $SEMAPHORE_GIT_TAG_NAME $SEMAPHORE_GIT_URL $SEMAPHORE_GIT_DIR
     if [ $? -ne 0 ]; then
       echo "Release $SEMAPHORE_GIT_TAG_NAME not found .... Exiting"
-
+      checkout::error_metric
       return 1
     else
       cd $SEMAPHORE_GIT_DIR
@@ -253,6 +257,12 @@ function checkout::refbased() {
 function checkout::metric() {
   if [[ "${SEMAPHORE_TOOLBOX_METRICS_ENABLED:-''}" == "true" ]]; then
     echo "libcheckout_repo_size $1" >> /tmp/toolbox_metrics
+  fi
+}
+
+function checkout::error_metric() {
+  if [[ "${SEMAPHORE_TOOLBOX_METRICS_ENABLED:-''}" == "true" ]]; then
+    echo "libcheckout_error 1" >> /tmp/toolbox_metrics
   fi
 }
 

--- a/libcheckout
+++ b/libcheckout
@@ -263,15 +263,21 @@ function checkout::metric() {
 
 function checkout::error_metric() {
   if [[ "${SEMAPHORE_TOOLBOX_METRICS_ENABLED:-''}" == "true" ]]; then
-    echo "libcheckout_error{provider='$SEMAPHORE_GIT_PROVIDER'} 1" >> /tmp/toolbox_metrics
-    echo "libcheckout_error{reftype='$SEMAPHORE_GIT_REF_TYPE'} 1" >> /tmp/toolbox_metrics
+    if [ -n ${SEMAPHORE_GIT_DEPTH:-""} ]; then
+      echo "libcheckout_error{provider='$SEMAPHORE_GIT_PROVIDER', reftype='$SEMAPHORE_GIT_REF_TYPE'} 1" >> /tmp/toolbox_metrics
+    else
+      echo "libcheckout_error{reftype='$SEMAPHORE_GIT_PROVIDER'} 1" >> /tmp/toolbox_metrics
+    fi
   fi
 }
 
 function checkout::success_metric() {
   if [[ "${SEMAPHORE_TOOLBOX_METRICS_ENABLED:-''}" == "true" ]]; then
-    echo "libcheckout_error{provider='$SEMAPHORE_GIT_PROVIDER'} 0" >> /tmp/toolbox_metrics
-    echo "libcheckout_error{reftype='$SEMAPHORE_GIT_REF_TYPE'} 0" >> /tmp/toolbox_metrics
+    if [ -n ${SEMAPHORE_GIT_DEPTH:-""} ]; then
+      echo "libcheckout_error{provider='$SEMAPHORE_GIT_PROVIDER', reftype='$SEMAPHORE_GIT_REF_TYPE'} 0" >> /tmp/toolbox_metrics
+    else
+      echo "libcheckout_error{reftype='$SEMAPHORE_GIT_PROVIDER'} 0" >> /tmp/toolbox_metrics
+    fi
   fi
 }
 

--- a/libcheckout
+++ b/libcheckout
@@ -17,11 +17,14 @@ function checkout() {
       checkout::shallow
     fi
 
-    if [ "$?" -ne "0" ]; then
+    exit_code=$?
+    if [ "$exit_code" -ne "0" ]; then
       checkout::error_metric
     else
       checkout::success_metric
     fi
+
+    return $exit_code
   fi
 }
 

--- a/libcheckout
+++ b/libcheckout
@@ -266,21 +266,15 @@ function checkout::metric() {
 
 function checkout::error_metric() {
   if [[ "${SEMAPHORE_TOOLBOX_METRICS_ENABLED:-''}" == "true" ]]; then
-    if [ -n ${SEMAPHORE_GIT_REF_TYPE:-""} ]; then
-      echo "libcheckout_error{provider='$SEMAPHORE_GIT_PROVIDER', reftype='$SEMAPHORE_GIT_REF_TYPE'} 1" >> /tmp/toolbox_metrics
-    else
-      echo "libcheckout_error{reftype='$SEMAPHORE_GIT_PROVIDER'} 1" >> /tmp/toolbox_metrics
-    fi
+    ref_type=${SEMAPHORE_GIT_REF_TYPE:-""}
+    echo "libcheckout_error{provider='$SEMAPHORE_GIT_PROVIDER', reftype='$ref_type'} 1" >> /tmp/toolbox_metrics
   fi
 }
 
 function checkout::success_metric() {
   if [[ "${SEMAPHORE_TOOLBOX_METRICS_ENABLED:-''}" == "true" ]]; then
-    if [ -n ${SEMAPHORE_GIT_REF_TYPE:-""} ]; then
-      echo "libcheckout_error{provider='$SEMAPHORE_GIT_PROVIDER', reftype='$SEMAPHORE_GIT_REF_TYPE'} 0" >> /tmp/toolbox_metrics
-    else
-      echo "libcheckout_error{reftype='$SEMAPHORE_GIT_PROVIDER'} 0" >> /tmp/toolbox_metrics
-    fi
+    ref_type=${SEMAPHORE_GIT_REF_TYPE:-""}
+    echo "libcheckout_error{provider='$SEMAPHORE_GIT_PROVIDER', reftype='$ref_type'} 0" >> /tmp/toolbox_metrics
   fi
 }
 

--- a/libcheckout
+++ b/libcheckout
@@ -263,7 +263,7 @@ function checkout::metric() {
 
 function checkout::error_metric() {
   if [[ "${SEMAPHORE_TOOLBOX_METRICS_ENABLED:-''}" == "true" ]]; then
-    if [ -n ${SEMAPHORE_GIT_DEPTH:-""} ]; then
+    if [ -n ${SEMAPHORE_GIT_REF_TYPE:-""} ]; then
       echo "libcheckout_error{provider='$SEMAPHORE_GIT_PROVIDER', reftype='$SEMAPHORE_GIT_REF_TYPE'} 1" >> /tmp/toolbox_metrics
     else
       echo "libcheckout_error{reftype='$SEMAPHORE_GIT_PROVIDER'} 1" >> /tmp/toolbox_metrics
@@ -273,7 +273,7 @@ function checkout::error_metric() {
 
 function checkout::success_metric() {
   if [[ "${SEMAPHORE_TOOLBOX_METRICS_ENABLED:-''}" == "true" ]]; then
-    if [ -n ${SEMAPHORE_GIT_DEPTH:-""} ]; then
+    if [ -n ${SEMAPHORE_GIT_REF_TYPE:-""} ]; then
       echo "libcheckout_error{provider='$SEMAPHORE_GIT_PROVIDER', reftype='$SEMAPHORE_GIT_REF_TYPE'} 0" >> /tmp/toolbox_metrics
     else
       echo "libcheckout_error{reftype='$SEMAPHORE_GIT_PROVIDER'} 0" >> /tmp/toolbox_metrics

--- a/libcheckout
+++ b/libcheckout
@@ -263,13 +263,15 @@ function checkout::metric() {
 
 function checkout::error_metric() {
   if [[ "${SEMAPHORE_TOOLBOX_METRICS_ENABLED:-''}" == "true" ]]; then
-    echo "libcheckout_error 1" >> /tmp/toolbox_metrics
+    echo "libcheckout_error{provider='$SEMAPHORE_GIT_PROVIDER'} 1" >> /tmp/toolbox_metrics
+    echo "libcheckout_error{reftype='$SEMAPHORE_GIT_REF_TYPE'} 1" >> /tmp/toolbox_metrics
   fi
 }
 
 function checkout::success_metric() {
   if [[ "${SEMAPHORE_TOOLBOX_METRICS_ENABLED:-''}" == "true" ]]; then
-    echo "libcheckout_error 0" >> /tmp/toolbox_metrics
+    echo "libcheckout_error{provider='$SEMAPHORE_GIT_PROVIDER'} 0" >> /tmp/toolbox_metrics
+    echo "libcheckout_error{reftype='$SEMAPHORE_GIT_REF_TYPE'} 0" >> /tmp/toolbox_metrics
   fi
 }
 

--- a/libcheckout
+++ b/libcheckout
@@ -16,6 +16,12 @@ function checkout() {
     else
       checkout::shallow
     fi
+
+    if [ "$?" -ne "0" ]; then
+      checkout::error_metric
+    else
+      checkout::success_metric
+    fi
   fi
 }
 
@@ -185,7 +191,6 @@ function checkout::shallow() {
     cd "$SEMAPHORE_GIT_DIR"
     checkout::branch_checkout
     if [ $? -ne 0 ]; then
-      checkout::error_metric
       return 1
     fi
 
@@ -193,7 +198,6 @@ function checkout::shallow() {
     if [ "$?" -eq "0" ]; then
       git reset --hard $SEMAPHORE_GIT_SHA 2>/dev/null
     else
-      checkout::error_metric
       return 1
     fi
   else
@@ -206,7 +210,6 @@ function checkout::shallow() {
       if [ "$?" -eq "0" ]; then
         git reset --hard $SEMAPHORE_GIT_SHA 2>/dev/null
       else
-        checkout::error_metric
         return 1
       fi
     fi
@@ -226,7 +229,6 @@ function checkout::refbased() {
     retry git fetch origin +$SEMAPHORE_GIT_REF: 2>/dev/null
     if [ $? -ne 0 ]; then
       echo "Revision: ${SEMAPHORE_GIT_SHA} not found .... Exiting"
-      checkout::error_metric
       return 1
     else
       git checkout -qf FETCH_HEAD
@@ -240,7 +242,6 @@ function checkout::refbased() {
     retry git clone --depth $SEMAPHORE_GIT_DEPTH -b $SEMAPHORE_GIT_TAG_NAME $SEMAPHORE_GIT_URL $SEMAPHORE_GIT_DIR
     if [ $? -ne 0 ]; then
       echo "Release $SEMAPHORE_GIT_TAG_NAME not found .... Exiting"
-      checkout::error_metric
       return 1
     else
       cd $SEMAPHORE_GIT_DIR
@@ -263,6 +264,12 @@ function checkout::metric() {
 function checkout::error_metric() {
   if [[ "${SEMAPHORE_TOOLBOX_METRICS_ENABLED:-''}" == "true" ]]; then
     echo "libcheckout_error 1" >> /tmp/toolbox_metrics
+  fi
+}
+
+function checkout::success_metric() {
+  if [[ "${SEMAPHORE_TOOLBOX_METRICS_ENABLED:-''}" == "true" ]]; then
+    echo "libcheckout_error 0" >> /tmp/toolbox_metrics
   fi
 }
 


### PR DESCRIPTION
We should track how often the checkout command fails, so we can alert on it.