### PR TITLE
fix: address shellcheck warnings

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -60,12 +60,9 @@ blocks:
           commands:
             - shellcheck sem-service || true
             - shellcheck sem-version || true
-            - shellcheck cache       || true
-            - shellcheck sem-context || true
             - shellcheck libcheckout || true
             - 'shellcheck sem-service -f gcc | wc -l && [[ "$(shellcheck sem-service -f gcc | wc -l)" -le 76 ]]'
             - 'shellcheck sem-version -f gcc | wc -l && [[ "$(shellcheck sem-version -f gcc | wc -l)" -le 21 ]]'
-            - 'shellcheck cache       -f gcc | wc -l && [[ "$(shellcheck cache -f gcc | wc -l)" -le 152 ]]'
             - 'shellcheck libcheckout -f gcc | wc -l && [[ "$(shellcheck libcheckout -f gcc | wc -l)" -le 90 ]]'
             - shellcheck install-package
             - shellcheck sem-semantic-release

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -59,10 +59,9 @@ blocks:
         - name: Shell check
           commands:
             - shellcheck sem-service || true
-            - shellcheck sem-version || true
+            - shellcheck sem-version
             - shellcheck libcheckout || true
             - 'shellcheck sem-service -f gcc | wc -l && [[ "$(shellcheck sem-service -f gcc | wc -l)" -le 76 ]]'
-            - 'shellcheck sem-version -f gcc | wc -l && [[ "$(shellcheck sem-version -f gcc | wc -l)" -le 21 ]]'
             - 'shellcheck libcheckout -f gcc | wc -l && [[ "$(shellcheck libcheckout -f gcc | wc -l)" -le 90 ]]'
             - shellcheck install-package
             - shellcheck sem-semantic-release

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -60,9 +60,8 @@ blocks:
           commands:
             - shellcheck sem-service || true
             - shellcheck sem-version
-            - shellcheck libcheckout || true
+            - shellcheck -s bash libcheckout
             - 'shellcheck sem-service -f gcc | wc -l && [[ "$(shellcheck sem-service -f gcc | wc -l)" -le 76 ]]'
-            - 'shellcheck libcheckout -f gcc | wc -l && [[ "$(shellcheck libcheckout -f gcc | wc -l)" -le 90 ]]'
             - shellcheck install-package
             - shellcheck sem-semantic-release
         - name: PowerShell check

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -58,10 +58,9 @@ blocks:
       jobs:
         - name: Shell check
           commands:
-            - shellcheck sem-service || true
+            - shellcheck sem-service
             - shellcheck sem-version
             - shellcheck -s bash libcheckout
-            - 'shellcheck sem-service -f gcc | wc -l && [[ "$(shellcheck sem-service -f gcc | wc -l)" -le 76 ]]'
             - shellcheck install-package
             - shellcheck sem-semantic-release
         - name: PowerShell check

--- a/libcheckout
+++ b/libcheckout
@@ -119,7 +119,7 @@ function checkout::switch_revision() {
 
 function checkout::cache_store() {
   # update cache if older then 72h -> 25920s
-  if [ -z "${SEMAPHORE_GIT_CACHE_AGE:-''}" ]; then
+  if [ -z "${SEMAPHORE_GIT_CACHE_AGE:-""}" ]; then
     SEMAPHORE_GIT_CACHE_AGE=259200
   fi
 
@@ -132,7 +132,8 @@ function checkout::cache_store() {
     local diff=$(($(date +%s) - cache_age))
     echo "diff: $diff"
 
-    if (( diff > SEMAPHORE_GIT_CACHE_AGE )); then
+    # shellcheck disable=SC2004
+    if (( diff > $SEMAPHORE_GIT_CACHE_AGE )); then
       echo "Git cache outdated, refreshing..."
       cd ..
       checkout::cleanupcache

--- a/libcheckout
+++ b/libcheckout
@@ -119,9 +119,7 @@ function checkout::switch_revision() {
 
 function checkout::cache_store() {
   # update cache if older then 72h -> 25920s
-  if [ -z "${SEMAPHORE_GIT_CACHE_AGE:-""}" ]; then
-    SEMAPHORE_GIT_CACHE_AGE=259200
-  fi
+  SEMAPHORE_GIT_CACHE_AGE="${SEMAPHORE_GIT_CACHE_AGE:-259200}"
 
   local cache_key
   local cache_age
@@ -132,8 +130,7 @@ function checkout::cache_store() {
     local diff=$(($(date +%s) - cache_age))
     echo "diff: $diff"
 
-    # shellcheck disable=SC2004
-    if (( diff > $SEMAPHORE_GIT_CACHE_AGE )); then
+    if (( diff > SEMAPHORE_GIT_CACHE_AGE )); then
       echo "Git cache outdated, refreshing..."
       cd ..
       checkout::cleanupcache
@@ -157,8 +154,8 @@ function checkout::cleanupcache {
   fi
   local k=$SEMAPHORE_GIT_CACHE_KEEP
 
-  # shellcheck disable=SC2207
-  local list=($(cache list 2>&1 | grep git-cache- | awk '{ print $1 }' | xargs))
+  local list=()
+  while IFS='' read -r line; do list+=("$line"); done < <(cache list 2>&1 | grep git-cache- | awk '{ print $1 }')
 
   for i in "${list[@]:$k}"; do
     cache delete "${i}"

--- a/libcheckout
+++ b/libcheckout
@@ -48,6 +48,8 @@ function checkout::use_cache() {
     checkout::clone
   fi
 
+  # SC2181: checking the last command's exit code
+  # with $? simplifies the control flow of this function.
   # shellcheck disable=SC2181
   if [ "$?" -eq "0" ]; then
     checkout::cache_store

--- a/libcheckout
+++ b/libcheckout
@@ -1,6 +1,6 @@
 function checkout() {
   local use_cache=${1:-""}
-  if [ -z $SEMAPHORE_GIT_BRANCH ] || [ -z $SEMAPHORE_GIT_URL ] || [ -z $SEMAPHORE_GIT_DIR ] || [ -z $SEMAPHORE_GIT_SHA ]; then
+  if [ -z "${SEMAPHORE_GIT_BRANCH}" ] || [ -z "${SEMAPHORE_GIT_URL}" ] || [ -z "${SEMAPHORE_GIT_DIR}" ] || [ -z "${SEMAPHORE_GIT_SHA}" ]; then
     checkout::validation_message
     return 1
   fi
@@ -11,7 +11,7 @@ function checkout() {
     echo "[Experimental stability] Using cached Git repository."
     checkout::use_cache
   else
-    if [ ! -z ${SEMAPHORE_GIT_REF_TYPE:-} ]; then
+    if [ -n "${SEMAPHORE_GIT_REF_TYPE:-}" ]; then
       checkout::refbased
     else
       checkout::shallow
@@ -36,11 +36,10 @@ function checkout::validation_message() {
 
 function checkout::use_cache() {
   export CACHE_FAIL_ON_ERROR="true"
-  cache restore git-cache-
 
-  if [ "$?" -ne "0" ]; then
+  if ! cache restore git-cache-; then
     echo "Failed to restore from the cache"
-    rm -rf $SEMAPHORE_GIT_DIR
+    rm -rf "${SEMAPHORE_GIT_DIR}"
   fi
 
   if [ -d "$HOME/$SEMAPHORE_GIT_DIR" ]; then
@@ -49,6 +48,7 @@ function checkout::use_cache() {
     checkout::clone
   fi
 
+  # shellcheck disable=SC2181
   if [ "$?" -eq "0" ]; then
     checkout::cache_store
   else
@@ -58,7 +58,7 @@ function checkout::use_cache() {
 
 function checkout::fetch() {
   echo "Restored cache"
-  cd $HOME/$SEMAPHORE_GIT_DIR
+  cd "${HOME}/${SEMAPHORE_GIT_DIR}" || exit
   git remote prune origin
   retry git fetch --tags origin
 
@@ -66,16 +66,15 @@ function checkout::fetch() {
 }
 
 function checkout::clone() {
-  retry git clone $SEMAPHORE_GIT_URL $SEMAPHORE_GIT_DIR
-  cd $SEMAPHORE_GIT_DIR
+  retry git clone "${SEMAPHORE_GIT_URL}" "${SEMAPHORE_GIT_DIR}"
+  cd "${SEMAPHORE_GIT_DIR}" || exit
 
   checkout::switch_revision
 }
 
 function checkout::reset_to_sha {
-  checkout::checkrevision
-  if [ "$?" -eq "0" ]; then
-    git reset --hard $SEMAPHORE_GIT_SHA 2>/dev/null
+  if checkout::checkrevision; then
+    git reset --hard "${SEMAPHORE_GIT_SHA}" 2>/dev/null
     checkout::metric "$(du -s . | awk '{ print $1 }')"
     return 0
   else
@@ -84,9 +83,8 @@ function checkout::reset_to_sha {
 }
 
 function checkout::switch_revision() {
-  if [ ${SEMAPHORE_GIT_REF_TYPE:-""} = "pull-request" ]; then
-    retry git fetch origin +$SEMAPHORE_GIT_REF: 2>/dev/null
-    if [ $? -ne 0 ]; then
+  if [ "${SEMAPHORE_GIT_REF_TYPE:-""}" = "pull-request" ]; then
+    if ! retry git fetch origin +"${SEMAPHORE_GIT_REF}": 2>/dev/null; then
       echo "Reference: ${SEMAPHORE_GIT_REF} not found .... Exiting"
 
       return 1
@@ -94,9 +92,8 @@ function checkout::switch_revision() {
       checkout::reset_to_sha
     fi
 
-  elif [ ${SEMAPHORE_GIT_REF_TYPE:-""} = "tag" ]; then
-    git checkout -qf $SEMAPHORE_GIT_TAG_NAME
-    if [ $? -ne 0 ]; then
+  elif [ "${SEMAPHORE_GIT_REF_TYPE:-''}" = "tag" ]; then
+    if ! git checkout -qf "${SEMAPHORE_GIT_TAG_NAME}"; then
       echo "Release $SEMAPHORE_GIT_TAG_NAME not found .... Exiting"
 
       return 1
@@ -108,13 +105,12 @@ function checkout::switch_revision() {
     fi
 
   else
-    local branch_ref="refs/heads/$SEMAPHORE_GIT_BRANCH"
     local branch_origin="origin/$SEMAPHORE_GIT_BRANCH"
 
-    if [[ -n $(git show-ref $SEMAPHORE_GIT_REF) ]]; then
-      git checkout $SEMAPHORE_GIT_BRANCH
+    if [[ -n $(git show-ref "${SEMAPHORE_GIT_REF}") ]]; then
+      git checkout "${SEMAPHORE_GIT_BRANCH}"
     else
-      git checkout -b $SEMAPHORE_GIT_BRANCH -t $branch_origin;
+      git checkout -b "${SEMAPHORE_GIT_BRANCH}" -t "${branch_origin}";
     fi
 
     checkout::reset_to_sha
@@ -123,93 +119,95 @@ function checkout::switch_revision() {
 
 function checkout::cache_store() {
   # update cache if older then 72h -> 25920s
-  if [ -z ${SEMAPHORE_GIT_CACHE_AGE:-""} ]; then
+  if [ -z "${SEMAPHORE_GIT_CACHE_AGE:-''}" ]; then
     SEMAPHORE_GIT_CACHE_AGE=259200
   fi
 
-  local cache_key=$(cache list 2>&1 | grep git-cache- | awk '{ print $1 }' | head -1)
-  local cache_age=$(echo $cache_key | cut -d'-' -f8)
+  local cache_key
+  local cache_age
+  cache_key=$(cache list 2>&1 | grep git-cache- | awk '{ print $1 }' | head -1)
+  cache_age=$(echo "${cache_key}" | cut -d'-' -f8)
 
-  if [[ ! -z "$cache_age" ]] && [[ $cache_age =~ ^[0-9]+$ ]]; then
-    local now=$(date +%s)
-    local diff=$(expr $now - $cache_age)
+  if [[ -n "$cache_age" ]] && [[ $cache_age =~ ^[0-9]+$ ]]; then
+    local diff=$(($(date +%s) - cache_age))
     echo "diff: $diff"
-    if (( diff > $SEMAPHORE_GIT_CACHE_AGE )); then
+
+    if (( diff > SEMAPHORE_GIT_CACHE_AGE )); then
       echo "Git cache outdated, refreshing..."
       cd ..
       checkout::cleanupcache
-      cache store "git-cache-$SEMAPHORE_JOB_ID-`date +%s`" $SEMAPHORE_GIT_DIR
-      cd $SEMAPHORE_GIT_DIR
+      cache store "git-cache-$SEMAPHORE_JOB_ID-$(date +%s)" "${SEMAPHORE_GIT_DIR}"
+      cd "${SEMAPHORE_GIT_DIR}" || exit
     else
       echo "Git cache up-to-data."
     fi
+
   else
     echo "No git cache... caching"
     cd ..
-    cache store "git-cache-${SEMAPHORE_JOB_ID}-`date +%s`" $SEMAPHORE_GIT_DIR
-    cd $SEMAPHORE_GIT_DIR
+    cache store "git-cache-${SEMAPHORE_JOB_ID}-$(date +%s)" "${SEMAPHORE_GIT_DIR}"
+    cd "${SEMAPHORE_GIT_DIR}" || exit
   fi
 }
 
 function checkout::cleanupcache {
-  if [ -z ${SEMAPHORE_GIT_CACHE_KEEP:-""} ]; then
+  if [ -z "${SEMAPHORE_GIT_CACHE_KEEP:-""}" ]; then
     SEMAPHORE_GIT_CACHE_KEEP=0
   fi
   local k=$SEMAPHORE_GIT_CACHE_KEEP
+
+  # shellcheck disable=SC2207
   local list=($(cache list 2>&1 | grep git-cache- | awk '{ print $1 }' | xargs))
 
-  for i in ${list[@]:$k}; do
-    cache delete $i
+  for i in "${list[@]:$k}"; do
+    cache delete "${i}"
   done
 
 }
 
 function checkout::checkrevision {
-  git rev-list HEAD..$SEMAPHORE_GIT_SHA 2>/dev/null
-  if [ $? -ne 0 ]; then
+  if ! git rev-list HEAD.."${SEMAPHORE_GIT_SHA}" 2>/dev/null; then
     echo "Revision: ${SEMAPHORE_GIT_SHA} not found .... Exiting"
     return 1
   fi
 }
 
 function checkout::branch_checkout {
-  git checkout -f "$SEMAPHORE_GIT_BRANCH"
-  if [ $? -ne 0 ]; then
+  if ! git checkout -f "$SEMAPHORE_GIT_BRANCH"; then
     echo "Branch: ${SEMAPHORE_GIT_BRANCH} not found .... Exiting"
     return 1
   fi
 }
 
 function checkout::shallow() {
-  if [ -z ${SEMAPHORE_GIT_DEPTH:-""} ]; then
+  if [ -z "${SEMAPHORE_GIT_DEPTH:-""}" ]; then
     SEMAPHORE_GIT_DEPTH=50
   fi
   echo "Performing shallow clone with depth: $SEMAPHORE_GIT_DEPTH"
-  retry git clone --depth $SEMAPHORE_GIT_DEPTH -b $SEMAPHORE_GIT_BRANCH $SEMAPHORE_GIT_URL $SEMAPHORE_GIT_DIR
-  if [ $? -ne 0 ]; then
+
+  if ! retry git clone --depth "${SEMAPHORE_GIT_DEPTH}" -b "${SEMAPHORE_GIT_BRANCH}" "${SEMAPHORE_GIT_URL}" "${SEMAPHORE_GIT_DIR}"; then
     echo "Branch not found performing full clone"
-    retry git clone $SEMAPHORE_GIT_URL $SEMAPHORE_GIT_DIR
-    cd "$SEMAPHORE_GIT_DIR"
-    checkout::branch_checkout
-    if [ $? -ne 0 ]; then
+    retry git clone "${SEMAPHORE_GIT_URL}" "${SEMAPHORE_GIT_DIR}"
+    cd "$SEMAPHORE_GIT_DIR" || exit
+
+    if ! checkout::branch_checkout; then
       return 1
     fi
 
-    checkout::checkrevision
-    if [ "$?" -eq "0" ]; then
-      git reset --hard $SEMAPHORE_GIT_SHA 2>/dev/null
+    if checkout::checkrevision; then
+      git reset --hard "${SEMAPHORE_GIT_SHA}" 2>/dev/null
     else
       return 1
     fi
   else
-    cd $SEMAPHORE_GIT_DIR
-    git reset --hard $SEMAPHORE_GIT_SHA 2>/dev/null
-    if [ $? -ne 0 ]; then
+    cd "${SEMAPHORE_GIT_DIR}" || exit
+
+    if ! git reset --hard "${SEMAPHORE_GIT_SHA}" 2>/dev/null; then
       echo "SHA: $SEMAPHORE_GIT_SHA not found performing full clone"
       retry git fetch --unshallow
-      checkout::checkrevision
-      if [ "$?" -eq "0" ]; then
-        git reset --hard $SEMAPHORE_GIT_SHA 2>/dev/null
+
+      if checkout::checkrevision; then
+        git reset --hard "${SEMAPHORE_GIT_SHA}" 2>/dev/null
       else
         return 1
       fi
@@ -220,15 +218,15 @@ function checkout::shallow() {
 }
 
 function checkout::refbased() {
-  if [ -z ${SEMAPHORE_GIT_DEPTH:-""} ]; then
+  if [ -z "${SEMAPHORE_GIT_DEPTH:-""}" ]; then
     SEMAPHORE_GIT_DEPTH=50
   fi
 
-  if [ ${SEMAPHORE_GIT_REF_TYPE:-""} = "pull-request" ]; then
-    retry git clone --depth $SEMAPHORE_GIT_DEPTH $SEMAPHORE_GIT_URL $SEMAPHORE_GIT_DIR
-    cd $SEMAPHORE_GIT_DIR
-    retry git fetch origin +$SEMAPHORE_GIT_REF: 2>/dev/null
-    if [ $? -ne 0 ]; then
+  if [ "${SEMAPHORE_GIT_REF_TYPE:-""}" = "pull-request" ]; then
+    retry git clone --depth "${SEMAPHORE_GIT_DEPTH}" "${SEMAPHORE_GIT_URL}" "${SEMAPHORE_GIT_DIR}"
+    cd "${SEMAPHORE_GIT_DIR}" || exit
+
+    if ! retry git fetch origin +"${SEMAPHORE_GIT_REF}": 2>/dev/null; then
       echo "Revision: ${SEMAPHORE_GIT_SHA} not found .... Exiting"
       return 1
     else
@@ -239,14 +237,13 @@ function checkout::refbased() {
     fi
   fi
 
-  if [ ${SEMAPHORE_GIT_REF_TYPE:-""} = "tag" ]; then
-    retry git clone --depth $SEMAPHORE_GIT_DEPTH -b $SEMAPHORE_GIT_TAG_NAME $SEMAPHORE_GIT_URL $SEMAPHORE_GIT_DIR
-    if [ $? -ne 0 ]; then
+  if [ "${SEMAPHORE_GIT_REF_TYPE:-""}" = "tag" ]; then
+    if ! retry git clone --depth "${SEMAPHORE_GIT_DEPTH}" -b "${SEMAPHORE_GIT_TAG_NAME}" "${SEMAPHORE_GIT_URL}" "${SEMAPHORE_GIT_DIR}"; then
       echo "Release $SEMAPHORE_GIT_TAG_NAME not found .... Exiting"
       return 1
     else
-      cd $SEMAPHORE_GIT_DIR
-      git checkout -qf $SEMAPHORE_GIT_TAG_NAME
+      cd "${SEMAPHORE_GIT_DIR}" || exit
+      git checkout -qf "${SEMAPHORE_GIT_TAG_NAME}"
       echo "HEAD is now at ${SEMAPHORE_GIT_SHA} Release ${SEMAPHORE_GIT_TAG_NAME}"
 
       return 0

--- a/sem-service
+++ b/sem-service
@@ -298,30 +298,30 @@ service::start() {
   case "$service_name" in
     "mysql" )
       shift
-      service_version=$(sem-service-check-params mysql "$@")
-      service::check_version 'mysql' "${service_version%% *}"
-      service::duration service::start_mysql "${service_version}" total "${service_name}"
+      IFS=" " read -r -a version_and_args <<< "$(sem-service-check-params mysql "$@")"
+      service::check_version 'mysql' "${version_and_args[0]}"
+      service::duration service::start_mysql "${version_and_args[@]}" total "${service_name}"
       exit 0
       ;;
     "postgres" )
       shift
-      service_version=$(sem-service-check-params postgres "$@")
-      service::check_version 'postgres' "${service_version%% *}"
-      service::duration service::start_postgres "${service_version}" total "${service_name}"
+      IFS=" " read -r -a version_and_args <<< "$(sem-service-check-params postgres "$@")"
+      service::check_version 'postgres' "${version_and_args[0]}"
+      service::duration service::start_postgres "${version_and_args[@]}" total "${service_name}"
       exit 0
       ;;
     "postgis" )
       shift
-      service_version=$(sem-service-check-params postgis "$@")
-      service::check_version 'postgis' "${service_version%% *}"
-      service::duration service::start_postgis "${service_version}" total "${service_name}"
+      IFS=" " read -r -a version_and_args <<< "$(sem-service-check-params postgis "$@")"
+      service::check_version 'postgis' "${version_and_args[0]}"
+      service::duration service::start_postgis "${version_and_args[@]}" total "${service_name}"
       exit 0
       ;;
     "redis" )
       shift
-      service_version=$(sem-service-check-params redis "$@")
-      service::check_version 'redis' "${service_version%% *}"
-      service::duration service::start_redis "${service_version}" total "${service_name}"
+      IFS=" " read -r -a version_and_args <<< "$(sem-service-check-params redis "$@")"
+      service::check_version 'redis' "${version_and_args[0]}"
+      service::duration service::start_redis "${version_and_args[@]}" total "${service_name}"
       exit 0
       ;;
     "memcached" )
@@ -333,9 +333,9 @@ service::start() {
       ;;
     "mongodb" )
       shift
-      service_version=$(sem-service-check-params mongodb "$@")
-      service::check_version 'mongo' "${service_version%% *}"
-      service::duration service::start_mongodb "${service_version}" total "${service_name}"
+      IFS=" " read -r -a version_and_args <<< "$(sem-service-check-params mongodb "$@")"
+      service::check_version 'mongo' "${version_and_args[0]}"
+      service::duration service::start_mongodb "${version_and_args[@]}" total "${service_name}"
       exit 0
       ;;
     "elasticsearch" )

--- a/sem-service
+++ b/sem-service
@@ -56,7 +56,9 @@ service::check_version(){
   local have_it=1
   local local_versions="${sem_services[$image_name]}"
 
-  for i in "${local_versions[@]}"; do
+  # SC2068: we want the word splitting here, so no double quotes
+  # shellcheck disable=SC2068
+  for i in ${local_versions[@]}; do
     if [ "$version" == "$i" ]; then
       have_it=0
       break

--- a/sem-service
+++ b/sem-service
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2155,SC2116
 
 # Misc
 DATE_FORMAT='%H:%M %d/%m/%Y'
@@ -44,6 +45,8 @@ service::pull_image() {
       fi
     fi
   fi
+
+  # shellcheck disable=SC2086
   service::duration service::run_cmd service::pull_image_retry pull "$image_name" download "$(echo ${image_name%%:*})"
 }
 
@@ -53,8 +56,8 @@ service::check_version(){
   local have_it=1
   local local_versions="${sem_services[$image_name]}"
 
-  for i in ${local_versions[@]};do
-    if [ "$version" == "$i" ];then
+  for i in "${local_versions[@]}"; do
+    if [ "$version" == "$i" ]; then
       have_it=0
       break
     fi
@@ -66,7 +69,7 @@ service::check_version(){
     echo -e "Available options for '$image_name' are:"
     echo -e ""
     local_versions="${sem_services[$image_name]}"
-    for v in ${local_versions[@]};do
+    for v in "${local_versions[@]}"; do
       echo -e "  \e[34m- sem-version start ${image_name} ${v}\e[0m"
     done
     echo -e ""
@@ -84,9 +87,9 @@ service::start_mysql() {
   shift
   local service_image="${registry_host}/mysql"
 
-  docker_params="$@"
+  docker_params=( "$@" )
   service::pull_image "$service_image:$service_version"
-  docker_output=$(docker run $docker_params "$service_image":"$service_version")
+  docker_output=$(docker run "${docker_params[@]}" "$service_image":"$service_version")
   # run only if previous command exited successfully
   docker_status=$(sem-dockerize 3306 mysql)
   if [ "$docker_status" == "0" ]; then
@@ -104,9 +107,9 @@ service::start_postgres() {
   shift
   local service_image="${registry_host}/postgres"
 
-  docker_params="$@"
+  docker_params=( "$@" )
   service::pull_image "$service_image:$service_version"
-  docker_output=$(docker run $docker_params "$service_image":"$service_version")
+  docker_output=$(docker run "${docker_params[@]}" "$service_image":"$service_version")
   # run only if previous command exited successfully
   docker_status=$(sem-dockerize 5432 postgres)
   if [ "$docker_status" == "0" ]; then
@@ -124,9 +127,9 @@ service::start_postgis() {
   shift
   local service_image="${registry_host}/postgis"
 
-  docker_params="$@"
+  docker_params=( "$@" )
   service::pull_image "$service_image:$service_version"
-  docker_output=$(docker run $docker_params "$service_image":"$service_version")
+  docker_output=$(docker run "${docker_params[@]}" "$service_image":"$service_version")
   # run only if previous command exited successfully
   service::duration sem-dockerize 5432 boot postgis
   docker_status=$(sem-dockerize 5432 postgis)
@@ -145,9 +148,9 @@ service::start_redis() {
   shift
   local service_image="${registry_host}/redis"
 
-  docker_params="$@"
+  docker_params=( "$@" )
   service::pull_image "$service_image:$service_version"
-  docker_output=$(docker run $docker_params "$service_image":"$service_version" --appendonly yes)
+  docker_output=$(docker run "${docker_params[@]}" "$service_image":"$service_version" --appendonly yes)
   # run only if previous command exited successfully
   docker_status=$(sem-dockerize 6379 redis)
   if [ "$docker_status" == "0" ]; then
@@ -181,9 +184,9 @@ service::start_mongodb() {
   shift
   local service_image="${registry_host}/mongo"
 
-  docker_params="$@"
+  docker_params=( "$@" )
   service::pull_image "$service_image:$service_version"
-  docker_output=$(docker run $docker_params "$service_image":"$service_version")
+  docker_output=$(docker run "${docker_params[@]}" "$service_image":"$service_version")
   # run only if previous command exited successfully
   docker_status=$(sem-dockerize 27017 mongodb)
   if [ "$docker_status" == "0" ]; then
@@ -293,79 +296,79 @@ service::start() {
   case "$service_name" in
     "mysql" )
       shift
-      service_version=$(sem-service-check-params mysql $@)
-      service::check_version 'mysql' ${service_version%% *}
-      service::duration service::start_mysql $service_version total $service_name
+      service_version=$(sem-service-check-params mysql "$@")
+      service::check_version 'mysql' "${service_version%% *}"
+      service::duration service::start_mysql "${service_version}" total "${service_name}"
       exit 0
       ;;
     "postgres" )
       shift
-      service_version=$(sem-service-check-params postgres $@)
-      service::check_version 'postgres' ${service_version%% *}
-      service::duration service::start_postgres $service_version total $service_name
+      service_version=$(sem-service-check-params postgres "$@")
+      service::check_version 'postgres' "${service_version%% *}"
+      service::duration service::start_postgres "${service_version}" total "${service_name}"
       exit 0
       ;;
     "postgis" )
       shift
-      service_version=$(sem-service-check-params postgis $@)
-      service::check_version 'postgis' ${service_version%% *}
-      service::duration service::start_postgis $service_version total $service_name
+      service_version=$(sem-service-check-params postgis "$@")
+      service::check_version 'postgis' "${service_version%% *}"
+      service::duration service::start_postgis "${service_version}" total "${service_name}"
       exit 0
       ;;
     "redis" )
       shift
-      service_version=$(sem-service-check-params redis $@)
-      service::check_version 'redis' ${service_version%% *}
-      service::duration service::start_redis $service_version total $service_name
+      service_version=$(sem-service-check-params redis "$@")
+      service::check_version 'redis' "${service_version%% *}"
+      service::duration service::start_redis "${service_version}" total "${service_name}"
       exit 0
       ;;
     "memcached" )
       shift
       service_version="${service_version:-1.5}"
-      service::check_version 'memcached' ${service_version%% *}
-      service::duration service::start_memcached $service_version total $service_name
+      service::check_version 'memcached' "${service_version%% *}"
+      service::duration service::start_memcached "${service_version}" total "${service_name}"
       exit 0
       ;;
     "mongodb" )
       shift
-      service_version=$(sem-service-check-params mongodb $@)
-      service::check_version 'mongo' ${service_version%% *}
-      service::duration service::start_mongodb $service_version total $service_name
+      service_version=$(sem-service-check-params mongodb "$@")
+      service::check_version 'mongo' "${service_version%% *}"
+      service::duration service::start_mongodb "${service_version}" total "${service_name}"
       exit 0
       ;;
     "elasticsearch" )
       shift
       service_version="${service_version:-6.5}"
-      service::check_version 'elasticsearch' ${service_version%% *}
-      service::duration service::start_elasticsearch $service_version total $service_name
+      service::check_version 'elasticsearch' "${service_version%% *}"
+      service::duration service::start_elasticsearch "${service_version}" total "${service_name}"
       exit 0
       ;;
     "opensearch" )
       shift
       service_version="${service_version:-2}"
-      service::check_version 'opensearch' ${service_version%% *}
-      service::duration service::start_opensearch $service_version total $service_name
+      service::check_version 'opensearch' "${service_version%% *}"
+      service::duration service::start_opensearch "${service_version}" total "${service_name}"
       exit 0
       ;;
     "rabbitmq" )
       shift
       service_version="${service_version:-3.8}"
-      service::check_version 'rabbitmq' ${service_version%% *}
-      service::duration service::start_rabbitmq $service_version total $service_name
+      service::check_version 'rabbitmq' "${service_version%% *}"
+      service::duration service::start_rabbitmq "${service_version}" total "${service_name}"
       exit 0
       ;;
     "cassandra" )
       shift
       service_version="${service_version:-3.11}"
-      service::check_version 'cassandra' ${service_version%% *}
-      service::duration service::start_cassandra $service_version total $service_name
+      service::check_version 'cassandra' "${service_version%% *}"
+      service::duration service::start_cassandra "${service_version}" total "${service_name}"
       exit 0
       ;;
     "rethinkdb" )
       shift
       service_version="${service_version:-2.3}"
-      service::check_version 'rethinkdb' ${service_version%% *}
-      service::duration service::start_rethinkdb $service_version total $service_name
+      service::check_version 'rethinkdb' "${service_version%% *}"
+      service::duration service::start_rethinkdb "${service_version}" total "${service_name}"
       exit 0
       ;;
 
@@ -379,15 +382,14 @@ service::start() {
 
 service::stop() {
   local service_name
-  local service_check_log
 
   service_name=$1
-  service_check_log=$( service::status $service_name &>/dev/null )
+  service::status "${service_name}" &>/dev/null
   service_status=$?
 
   if [[ $service_status -eq 0 ]]; then
-    stop_output=$( service::run_cmd docker stop $service_name )
-    sudo rm -rf /var/tmp/$service_name
+    service::run_cmd docker stop "${service_name}"
+    sudo rm -rf "/var/tmp/${service_name}"
 
     service::log "'${service_name}' stopped."
   else
@@ -409,10 +411,9 @@ service::stop() {
 ################################################################################
 service::status() {
   local service_name
-  local docker_ps
-
   service_name=$1
-  docker_ps=$(docker ps | grep $service_name &>/dev/null )
+
+  docker ps | grep "${service_name}" &>/dev/null
   service_status=$?
 
   if [[ $service_status -eq 0 ]]; then
@@ -435,19 +436,19 @@ service::status() {
 #   0,1...n
 ################################################################################
 service::run_cmd() {
-  local cmd=$@
+  local cmd=( "$@" )
   local out=""
   local status=0
 
   if [[ -n $DRYRUN ]]; then
-    service::log "Dry-running '${cmd}'"
+    service::log "Dry-running '${cmd[*]}'"
   else
-    out=$($cmd 2>&1)
+    out=$("${cmd[@]}" 2>&1)
     status=$?
   fi
 
   if ! [[ $status -eq 0 ]]; then
-    service::err "Failed to run command '${cmd}'\n\nReason:\n${out}"
+    service::err "Failed to run command '${cmd[*]}'\n\nReason:\n${out}"
   fi
 
   return $status
@@ -465,14 +466,12 @@ service::run_cmd() {
 ################################################################################
 service::port_info() {
   local service_name
-  local service_check_log
 
   service_name=$1
-  port_check_log=$( service::run_cmd sudo netstat -tlpn | grep $service_name 2>&1 )
-  port_status=$?
+  port_check_log=$( service::run_cmd sudo netstat -tlpn | grep "${service_name}" 2>&1 )
 
   if [[ $service_status -eq 0 ]]; then
-    listens_on=$( echo ${port_check_log} | awk '{print $4}' )
+    listens_on=$( echo "${port_check_log}" | awk '{print $4}' )
 
     echo "Listens on ${listens_on}"
   else
@@ -483,11 +482,11 @@ service::port_info() {
 }
 
 service::log() {
-  echo -e "[$(date +"${DATE_FORMAT}")]: $@" >&2
+  echo -e "[$(date +"${DATE_FORMAT}")]: $*" >&2
 }
 
 service::err() {
-  echo -e "\n! [$(date +"${DATE_FORMAT}")]: $@\n" >&2
+  echo -e "\n! [$(date +"${DATE_FORMAT}")]: $*\n" >&2
 
   exit 1
 }
@@ -509,7 +508,9 @@ service::print_usage() {
 }
 
 service::duration() {
+  # shellcheck disable=SC2178,SC2124
   local cmd=${@:1:$#-2}
+
   local service=$(echo "${@: -1}")
   local version=$(echo "${@: 2:1}")
   local type=$(echo "${@: -2:1}")
@@ -517,7 +518,10 @@ service::duration() {
   local end
   local duration
   start=$(date +%s%3N)
+
+  # shellcheck disable=SC2128
   $cmd
+
   end=$(date +%s%3N)
   duration=$(( end - start ))
   if [[ "$type" == "total" ]]; then
@@ -551,7 +555,7 @@ service::main () {
 }
 
 if [[ "$(uname)" == "Darwin" ]]; then
-  echo "`sem-service` is not supported in this environment."
+  echo "'sem-service' is not supported in this environment."
   echo "https://docs.semaphoreci.com/ci-cd-environment/sem-service-managing-databases-and-services-on-linux"
   exit 1
 else

--- a/sem-service
+++ b/sem-service
@@ -1,5 +1,6 @@
 #!/bin/bash
-# shellcheck disable=SC2155,SC2116
+# SC2116: style suggestion that we don't care about.
+# shellcheck disable=SC2116
 
 # Misc
 DATE_FORMAT='%H:%M %d/%m/%Y'
@@ -46,8 +47,7 @@ service::pull_image() {
     fi
   fi
 
-  # shellcheck disable=SC2086
-  service::duration service::run_cmd service::pull_image_retry pull "$image_name" download "$(echo ${image_name%%:*})"
+  service::duration service::run_cmd service::pull_image_retry pull "$image_name" download "$(echo "${image_name%%:*}")"
 }
 
 service::check_version(){
@@ -510,19 +510,21 @@ service::print_usage() {
 }
 
 service::duration() {
-  # shellcheck disable=SC2178,SC2124
-  local cmd=${@:1:$#-2}
-
-  local service=$(echo "${@: -1}")
-  local version=$(echo "${@: 2:1}")
-  local type=$(echo "${@: -2:1}")
+  local cmd
+  local service
+  local version
+  local type
   local start
   local end
   local duration
+
+  cmd=( "${@:1:$#-2}" )
+  service=$(echo "${@: -1}")
+  version=$(echo "${@: 2:1}")
+  type=$(echo "${@: -2:1}")
   start=$(date +%s%3N)
 
-  # shellcheck disable=SC2128
-  $cmd
+  "${cmd[@]}"
 
   end=$(date +%s%3N)
   duration=$(( end - start ))

--- a/sem-version
+++ b/sem-version
@@ -79,6 +79,7 @@ version::change_go() {
   version::change "change-go-version"
   ret=$?
 
+  # SC2155: we are not interested in the return value.
   # shellcheck disable=SC2155
   [[ "$ret" == "0" ]] && export PATH="$(go env GOPATH)/bin:${PATH}"
 
@@ -168,8 +169,11 @@ version::change_kubectl() {
   return $?
 }
 version::change_flutter() {
-  # shellcheck disable=SC2155,SC2012
-  local local_version=$(ls -1d /opt/flutter_"${software_version}"* | tail -1)
+  local local_version
+
+  # SC2012: we don't need to handle non-alphanumeric filenames.
+  # shellcheck disable=SC2012
+  local_version=$(ls -1d /opt/flutter_"${software_version}"* | tail -1)
   if test -d "${local_version}"; then
     rm -f /opt/flutter && ln -s "${local_version}" /opt/flutter
     version::change "/opt/flutter/bin/flutter --version | grep "

--- a/sem-version
+++ b/sem-version
@@ -2,7 +2,6 @@
 
 # Changing language versions
 VERSION="0.7"
-SUPPORTED_SOFTWARE=(elixir go java php ruby python node c cpp erlang scala firefox kubectl)
 
 # Misc
 DATE_FORMAT='%H:%M %d/%m/%Y'
@@ -20,25 +19,23 @@ SEMAPHORE_ARCH=$(uname -m)
 #  0, 1-127 (exit status of the language manager command)
 
 version::metrics() {
-  local cmd=$@
+  local cmd=( "$@" )
   local software=${1#"version::change_"}
-  local version=$2
   local start
   local end
-  local duration
   [ "$(uname)" == "Linux" ] && start=$(date +%s%3N)
   [ "$(uname)" == "Darwin" ] && start=$(gdate +%s%3N)
-  $cmd
+  "${cmd[@]}"
   ch_status=$?
   [ "$(uname)" == "Linux" ] && end=$(date +%s%3N)
   [ "$(uname)" == "Darwin" ] && end=$(gdate +%s%3N)
-  TOTAL_TIME=$(( $end - $start ))
+  TOTAL_TIME=$(( end - start ))
   return $ch_status
 }
 version::change() {
   command=$1
   version::log "Changing '${software}' to version ${software_version}"
-  eval $command $software_version
+  eval "$command" "$software_version"
   ch_status=$?
   return $ch_status
 }
@@ -81,7 +78,10 @@ version::change_elixir() {
 version::change_go() {
   version::change "change-go-version"
   ret=$?
+
+  # shellcheck disable=SC2155
   [[ "$ret" == "0" ]] && export PATH="$(go env GOPATH)/bin:${PATH}"
+
   return $ret
 }
 version::change_java() {
@@ -168,9 +168,10 @@ version::change_kubectl() {
   return $?
 }
 version::change_flutter() {
-  local local_version=$(ls -1d /opt/flutter_${software_version}* | tail -1)
-  if test -d ${local_version}; then
-    rm -f /opt/flutter && ln -s ${local_version}  /opt/flutter
+  # shellcheck disable=SC2155,SC2012
+  local local_version=$(ls -1d /opt/flutter_"${software_version}"* | tail -1)
+  if test -d "${local_version}"; then
+    rm -f /opt/flutter && ln -s "${local_version}" /opt/flutter
     version::change "/opt/flutter/bin/flutter --version | grep "
     return $?
   else
@@ -227,7 +228,7 @@ version::date() {
 #   none
 ################################################################################
 version::log() {
-  echo -e "\n[$(version::date)]: $@" >&2
+  echo -e "\n[$(version::date)]: $*" >&2
 }
 
 ################################################################################
@@ -240,15 +241,13 @@ version::log() {
 #   1
 ################################################################################
 version::err() {
-  echo -e "\n! [$(version::date)]: $@" >&2
+  echo -e "\n! [$(version::date)]: $*" >&2
 
   return 1
 }
 
 ################################################################################
 # The main entrypoint to the script. Holds the switching logic.
-# Globals:
-#   SUPPORTED_SOFTWARE
 # Arguments:
 #   'software', 'version'
 # Returns:
@@ -279,11 +278,11 @@ version::main() {
 
   fn_name="version::change_${software}"
 
-  if ! [[ $(type -t $fn_name) == function ]]; then
+  if ! [[ $(type -t "$fn_name") == function ]]; then
     version::err "Function '${fn_name}' not implemented. Software '${software}' might not be supported."
     return 1
   else
-    version::metrics version::change_${software} $software_version $force
+    version::metrics version::change_"${software}" "$software_version" "$force"
     fn_status=$?
     if [[ fn_status -ne 0 ]]; then
       version::err "Failed to switch version.\n"
@@ -302,7 +301,7 @@ sem-version() {
     if [[ "$1" == 'ruby' ]] || [[ "$1" == 'node' ]]; then
       version::main "$@"
     else
-      echo "`sem-version` is not supported in this environment."
+      echo "'sem-version' is not supported in this environment."
       echo "https://docs.semaphoreci.com/ci-cd-environment/sem-version-managing-language-versions-on-linux"
       exit 1
     fi


### PR DESCRIPTION
We run [shellcheck](https://github.com/koalaman/shellcheck) during our CI, but we don't do anything about it. We should. This pull request addressed all the warnings for `checkout`, `sem-service` and `sem-version`. The main complaints were:
- https://www.shellcheck.net/wiki/SC2068
- https://www.shellcheck.net/wiki/SC2086
- https://www.shellcheck.net/wiki/SC2236
- https://www.shellcheck.net/wiki/SC2181
- https://www.shellcheck.net/wiki/SC2164
- https://www.shellcheck.net/wiki/SC2124
- https://www.shellcheck.net/wiki/SC2128
- https://www.shellcheck.net/wiki/SC2145
- https://www.shellcheck.net/wiki/SC2034
