### PR TITLE
fix: upgrade go-based CLIs to use Go 1.20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.20.x
       - name: Check out repository code
         uses: actions/checkout@v2
       - name: Install gotestsum

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -15,7 +15,7 @@ blocks:
       jobs:
         - name: Build cache CLI
           commands:
-            - sem-version go 1.18
+            - sem-version go 1.20
             - "export GOPATH=~/go"
             - "export PATH=/home/semaphore/go/bin:$PATH"
             - checkout
@@ -32,7 +32,7 @@ blocks:
             - artifact push workflow bin/windows/cache.exe -d bin/windows/cache.exe
         - name: Build sem-context CLI
           commands:
-            - sem-version go 1.17
+            - sem-version go 1.20
             - "export GOPATH=~/go"
             - "export PATH=/home/semaphore/go/bin:$PATH"
             - checkout
@@ -542,7 +542,7 @@ blocks:
           value: "on"
       prologue:
         commands:
-          - sem-version go 1.18
+          - sem-version go 1.20
           - checkout && cd cache-cli
       jobs:
         - name: Lint

--- a/cache-cli/Dockerfile.dev
+++ b/cache-cli/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.20
 
 RUN go install gotest.tools/gotestsum@latest
 RUN mkdir /root/.ssh

--- a/cache-cli/go.mod
+++ b/cache-cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/semaphoreci/toolbox/cache-cli
 
-go 1.18
+go 1.20
 
 require (
 	cloud.google.com/go/storage v1.30.1

--- a/cache-cli/pkg/archive/native_archiver.go
+++ b/cache-cli/pkg/archive/native_archiver.go
@@ -207,7 +207,8 @@ func (a *NativeArchiver) Decompress(src string) (string, error) {
 			}
 
 			// #nosec
-			if _, err := io.Copy(outFile, tarReader); err != nil {
+			_, err = io.Copy(outFile, tarReader)
+			if err != nil {
 				log.Errorf("Error writing to file '%s': %v", header.Name, err)
 				hadError = true
 				_ = outFile.Close()

--- a/cache-cli/pkg/files/checksum.go
+++ b/cache-cli/pkg/files/checksum.go
@@ -7,8 +7,8 @@ import (
 	"os"
 )
 
-// #nosec
 func GenerateChecksum(filePath string) (string, error) {
+	// #nosec
 	file, err := os.Open(filePath)
 	if err != nil {
 		return "", err
@@ -16,6 +16,7 @@ func GenerateChecksum(filePath string) (string, error) {
 
 	defer file.Close()
 
+	// #nosec
 	hash := md5.New()
 	if _, err := io.Copy(hash, file); err != nil {
 		return "", err

--- a/sem-context/Dockerfile.dev
+++ b/sem-context/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.20
 
 RUN go get gotest.tools/gotestsum
 

--- a/sem-context/go.mod
+++ b/sem-context/go.mod
@@ -1,6 +1,6 @@
 module github.com/semaphoreci/toolbox/sem-context
 
-go 1.17
+go 1.20
 
 require github.com/spf13/cobra v1.5.0
 


### PR DESCRIPTION
Upgrade cache and sem-context CLIs to use Go 1.20. Additionally, fixed a few gosec warnings.