### PR TITLE
Add context.Context to APIs

### DIFF
--- a/cache-cli/cmd/clear.go
+++ b/cache-cli/cmd/clear.go
@@ -18,10 +18,10 @@ var clearCmd = &cobra.Command{
 }
 
 func RunClear(cmd *cobra.Command, args []string) {
-	storage, err := storage.InitStorage()
+	storage, err := storage.InitStorage(cmd.Context())
 	utils.Check(err)
 
-	err = storage.Clear()
+	err = storage.Clear(cmd.Context())
 	utils.Check(err)
 	log.Infof("Deleted all caches.")
 }

--- a/cache-cli/cmd/clear_test.go
+++ b/cache-cli/cmd/clear_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -13,13 +14,14 @@ import (
 )
 
 func Test__Clear(t *testing.T) {
+	ctx := context.TODO()
 	log.SetFormatter(new(logging.CustomFormatter))
 	log.SetLevel(log.InfoLevel)
 	log.SetOutput(openLogfileForTests(t))
 
-	runTestForAllBackends(t, func(backend string, storage storage.Storage) {
+	runTestForAllBackends(ctx, t, func(backend string, storage storage.Storage) {
 		t.Run(fmt.Sprintf("%s no keys", backend), func(*testing.T) {
-			err := storage.Clear()
+			err := storage.Clear(ctx)
 			assert.Nil(t, err)
 
 			RunClear(clearCmd, []string{})
@@ -29,13 +31,13 @@ func Test__Clear(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("%s with keys", backend), func(*testing.T) {
-			err := storage.Clear()
+			err := storage.Clear(ctx)
 			assert.Nil(t, err)
 
 			tempFile, _ := ioutil.TempFile(os.TempDir(), "*")
-			storage.Store("abc001", tempFile.Name())
+			storage.Store(ctx, "abc001", tempFile.Name())
 
-			RunClear(hasKeyCmd, []string{})
+			RunClear(clearCmd, []string{})
 			output := readOutputFromFile(t)
 
 			assert.Contains(t, output, "Deleted all caches.")

--- a/cache-cli/cmd/delete.go
+++ b/cache-cli/cmd/delete.go
@@ -24,14 +24,14 @@ func RunDelete(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	storage, err := storage.InitStorage()
+	storage, err := storage.InitStorage(cmd.Context())
 	utils.Check(err)
 
 	rawKey := args[0]
 	key := NormalizeKey(rawKey)
 
-	if ok, _ := storage.HasKey(key); ok {
-		err := storage.Delete(key)
+	if ok, _ := storage.HasKey(cmd.Context(), key); ok {
+		err := storage.Delete(cmd.Context(), key)
 		utils.Check(err)
 		log.Infof("Key '%s' is deleted.", key)
 	} else {

--- a/cache-cli/cmd/delete_test.go
+++ b/cache-cli/cmd/delete_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -13,11 +14,12 @@ import (
 )
 
 func Test__Delete(t *testing.T) {
+	ctx := context.TODO()
 	log.SetFormatter(new(logging.CustomFormatter))
 	log.SetLevel(log.InfoLevel)
 	log.SetOutput(openLogfileForTests(t))
 
-	runTestForAllBackends(t, func(backend string, storage storage.Storage) {
+	runTestForAllBackends(ctx, t, func(backend string, storage storage.Storage) {
 		t.Run(fmt.Sprintf("%s key is missing", backend), func(*testing.T) {
 			RunDelete(deleteCmd, []string{"this-key-does-not-exist"})
 			output := readOutputFromFile(t)
@@ -26,9 +28,9 @@ func Test__Delete(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("%s key is present", backend), func(*testing.T) {
-			storage.Clear()
+			storage.Clear(ctx)
 			tempFile, _ := ioutil.TempFile(os.TempDir(), "*")
-			storage.Store("abc001", tempFile.Name())
+			storage.Store(ctx, "abc001", tempFile.Name())
 
 			RunDelete(deleteCmd, []string{"abc001"})
 			output := readOutputFromFile(t)
@@ -37,7 +39,7 @@ func Test__Delete(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("%s normalizes key", backend), func(*testing.T) {
-			storage.Clear()
+			storage.Clear(ctx)
 			tempFile, _ := ioutil.TempFile(os.TempDir(), "*")
 			RunStore(NewStoreCommand(), []string{"abc/00/33", tempFile.Name()})
 

--- a/cache-cli/cmd/has_key.go
+++ b/cache-cli/cmd/has_key.go
@@ -28,12 +28,12 @@ func RunHasKey(cmd *cobra.Command, args []string) bool {
 		return true
 	}
 
-	storage, err := storage.InitStorage()
+	storage, err := storage.InitStorage(cmd.Context())
 	utils.Check(err)
 
 	rawKey := args[0]
 	key := NormalizeKey(rawKey)
-	exists, err := storage.HasKey(key)
+	exists, err := storage.HasKey(cmd.Context(), key)
 	utils.Check(err)
 
 	if exists {

--- a/cache-cli/cmd/has_key_test.go
+++ b/cache-cli/cmd/has_key_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -13,11 +14,12 @@ import (
 )
 
 func Test__HasKey(t *testing.T) {
+	ctx := context.TODO()
 	log.SetFormatter(new(logging.CustomFormatter))
 	log.SetLevel(log.InfoLevel)
 	log.SetOutput(openLogfileForTests(t))
 
-	runTestForAllBackends(t, func(backend string, storage storage.Storage) {
+	runTestForAllBackends(ctx, t, func(backend string, storage storage.Storage) {
 		t.Run(fmt.Sprintf("%s key is missing", backend), func(*testing.T) {
 			RunHasKey(hasKeyCmd, []string{"this-key-does-not-exist"})
 			output := readOutputFromFile(t)
@@ -26,9 +28,9 @@ func Test__HasKey(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("%s key is present", backend), func(*testing.T) {
-			storage.Clear()
+			storage.Clear(ctx)
 			tempFile, _ := ioutil.TempFile(os.TempDir(), "*")
-			storage.Store("abc001", tempFile.Name())
+			storage.Store(ctx, "abc001", tempFile.Name())
 
 			RunHasKey(hasKeyCmd, []string{"abc001"})
 			output := readOutputFromFile(t)
@@ -37,7 +39,7 @@ func Test__HasKey(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("%s normalizes key", backend), func(*testing.T) {
-			storage.Clear()
+			storage.Clear(ctx)
 			tempFile, _ := ioutil.TempFile(os.TempDir(), "*")
 			RunStore(NewStoreCommand(), []string{"abc/00/33", tempFile.Name()})
 

--- a/cache-cli/cmd/is_not_empty.go
+++ b/cache-cli/cmd/is_not_empty.go
@@ -23,10 +23,10 @@ var isNotEmptyCmd = &cobra.Command{
 }
 
 func RunIsNotEmpty(cmd *cobra.Command, args []string) bool {
-	storage, err := storage.InitStorage()
+	storage, err := storage.InitStorage(cmd.Context())
 	utils.Check(err)
 
-	isNotEmpty, err := storage.IsNotEmpty()
+	isNotEmpty, err := storage.IsNotEmpty(cmd.Context())
 	utils.Check(err)
 
 	return isNotEmpty

--- a/cache-cli/cmd/is_not_empty_test.go
+++ b/cache-cli/cmd/is_not_empty_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -11,16 +12,17 @@ import (
 )
 
 func Test__IsNotEmpty(t *testing.T) {
-	runTestForAllBackends(t, func(backend string, storage storage.Storage) {
+	ctx := context.TODO()
+	runTestForAllBackends(ctx, t, func(backend string, storage storage.Storage) {
 		t.Run(fmt.Sprintf("%s cache is empty", backend), func(*testing.T) {
-			storage.Clear()
+			storage.Clear(ctx)
 			assert.False(t, RunIsNotEmpty(isNotEmptyCmd, []string{}))
 		})
 
 		t.Run(fmt.Sprintf("%s cache is not empty", backend), func(*testing.T) {
-			storage.Clear()
+			storage.Clear(ctx)
 			tempFile, _ := ioutil.TempFile(os.TempDir(), "*")
-			storage.Store("abc001", tempFile.Name())
+			storage.Store(ctx, "abc001", tempFile.Name())
 
 			assert.True(t, RunIsNotEmpty(isNotEmptyCmd, []string{}))
 		})

--- a/cache-cli/cmd/list.go
+++ b/cache-cli/cmd/list.go
@@ -36,10 +36,10 @@ func RunList(cmd *cobra.Command, args []string) {
 	sortBy, err := cmd.Flags().GetString("sort-by")
 	utils.Check(err)
 
-	storage, err := storage.InitStorageWithConfig(storage.StorageConfig{SortKeysBy: sortBy})
+	storage, err := storage.InitStorageWithConfig(cmd.Context(), storage.StorageConfig{SortKeysBy: sortBy})
 	utils.Check(err)
 
-	keys, err := storage.List()
+	keys, err := storage.List(cmd.Context())
 	utils.Check(err)
 
 	if len(keys) == 0 {

--- a/cache-cli/cmd/list_test.go
+++ b/cache-cli/cmd/list_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -13,14 +14,15 @@ import (
 )
 
 func Test__List(t *testing.T) {
+	ctx := context.TODO()
 	listCmd := NewListCommand()
 	log.SetFormatter(new(logging.CustomFormatter))
 	log.SetLevel(log.InfoLevel)
 	log.SetOutput(openLogfileForTests(t))
 
-	runTestForAllBackends(t, func(backend string, storage storage.Storage) {
+	runTestForAllBackends(ctx, t, func(backend string, storage storage.Storage) {
 		t.Run(fmt.Sprintf("%s no keys", backend), func(*testing.T) {
-			storage.Clear()
+			storage.Clear(ctx)
 
 			RunList(listCmd, []string{""})
 			output := readOutputFromFile(t)
@@ -29,11 +31,11 @@ func Test__List(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("%s with keys", backend), func(*testing.T) {
-			storage.Clear()
+			storage.Clear(ctx)
 			tempFile, _ := ioutil.TempFile(os.TempDir(), "*")
-			storage.Store("abc001", tempFile.Name())
-			storage.Store("abc002", tempFile.Name())
-			storage.Store("abc003", tempFile.Name())
+			storage.Store(ctx, "abc001", tempFile.Name())
+			storage.Store(ctx, "abc002", tempFile.Name())
+			storage.Store(ctx, "abc003", tempFile.Name())
 
 			RunList(listCmd, []string{})
 			output := readOutputFromFile(t)

--- a/cache-cli/cmd/root_test.go
+++ b/cache-cli/cmd/root_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"os"
@@ -38,7 +39,7 @@ var testBackends = map[string]TestBackend{
 	},
 }
 
-func runTestForAllBackends(t *testing.T, test func(string, storage.Storage)) {
+func runTestForAllBackends(ctx context.Context, t *testing.T, test func(string, storage.Storage)) {
 	for backendType, testBackend := range testBackends {
 		if runtime.GOOS == "windows" && !testBackend.runInWindows {
 			continue
@@ -48,7 +49,7 @@ func runTestForAllBackends(t *testing.T, test func(string, storage.Storage)) {
 			os.Setenv(envVarName, envVarValue)
 		}
 
-		storage, err := storage.InitStorage()
+		storage, err := storage.InitStorage(ctx)
 		assert.Nil(t, err)
 		test(backendType, storage)
 	}

--- a/cache-cli/cmd/usage.go
+++ b/cache-cli/cmd/usage.go
@@ -19,10 +19,10 @@ var usageCmd = &cobra.Command{
 }
 
 func RunUsage(cmd *cobra.Command, args []string) {
-	storage, err := storage.InitStorage()
+	storage, err := storage.InitStorage(cmd.Context())
 	utils.Check(err)
 
-	summary, err := storage.Usage()
+	summary, err := storage.Usage(cmd.Context())
 	utils.Check(err)
 
 	if summary.Free == -1 {

--- a/cache-cli/cmd/usage_test.go
+++ b/cache-cli/cmd/usage_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -11,13 +12,14 @@ import (
 )
 
 func Test__Usage(t *testing.T) {
+	ctx := context.TODO()
 	log.SetFormatter(new(logging.CustomFormatter))
 	log.SetLevel(log.InfoLevel)
 	log.SetOutput(openLogfileForTests(t))
 
-	runTestForAllBackends(t, func(backend string, storage storage.Storage) {
+	runTestForAllBackends(ctx, t, func(backend string, storage storage.Storage) {
 		t.Run(fmt.Sprintf("%s empty cache", backend), func(t *testing.T) {
-			storage.Clear()
+			storage.Clear(ctx)
 
 			RunUsage(usageCmd, []string{})
 			output := readOutputFromFile(t)

--- a/cache-cli/main.go
+++ b/cache-cli/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"context"
 	"io"
 	"os"
+	"os/signal"
 	"path/filepath"
 
 	"github.com/semaphoreci/toolbox/cache-cli/cmd"
@@ -15,7 +17,10 @@ func main() {
 	log.SetOutput(logfile)
 	log.SetFormatter(new(logging.CustomFormatter))
 	log.SetLevel(log.InfoLevel)
-	cmd.Execute()
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+	cmd.RootCmd.ExecuteContext(ctx)
 }
 
 func OpenLogfile() io.Writer {

--- a/cache-cli/pkg/archive/archiver.go
+++ b/cache-cli/pkg/archive/archiver.go
@@ -1,14 +1,15 @@
 package archive
 
 import (
+	"context"
 	"os"
 
 	"github.com/semaphoreci/toolbox/cache-cli/pkg/metrics"
 )
 
 type Archiver interface {
-	Compress(dst, src string) error
-	Decompress(src string) (string, error)
+	Compress(ctx context.Context, dst, src string) error
+	Decompress(ctx context.Context, src string) (string, error)
 }
 
 func NewArchiver(metricsManager metrics.MetricsManager) Archiver {

--- a/cache-cli/pkg/archive/native_archiver.go
+++ b/cache-cli/pkg/archive/native_archiver.go
@@ -3,6 +3,7 @@ package archive
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -28,7 +29,7 @@ func NewNativeArchiver(metricsManager metrics.MetricsManager, useParallelism boo
 	}
 }
 
-func (a *NativeArchiver) Compress(dst, src string) error {
+func (a *NativeArchiver) Compress(ctx context.Context, dst, src string) error {
 	if _, err := os.Stat(src); err != nil {
 		return fmt.Errorf("error finding '%s': %v", src, err)
 	}
@@ -115,7 +116,7 @@ type directoryStat struct {
 	mode fs.FileMode
 }
 
-func (a *NativeArchiver) Decompress(src string) (string, error) {
+func (a *NativeArchiver) Decompress(ctx context.Context, src string) (string, error) {
 	// #nosec
 	srcFile, err := os.Open(src)
 	if err != nil {

--- a/cache-cli/pkg/storage/clear_test.go
+++ b/cache-cli/pkg/storage/clear_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -10,9 +11,10 @@ import (
 )
 
 func Test__Clear(t *testing.T) {
+	ctx := context.TODO()
 	runTestForAllStorageTypes(t, SortByStoreTime, func(storageType string, storage Storage) {
 		setup := func(storage Storage) []string {
-			_ = storage.Clear()
+			_ = storage.Clear(ctx)
 
 			file1, _ := ioutil.TempFile(os.TempDir(), "*")
 			file1.WriteString("something, something")
@@ -20,8 +22,8 @@ func Test__Clear(t *testing.T) {
 			file2, _ := ioutil.TempFile(os.TempDir(), "*")
 			file2.WriteString("else, else")
 
-			_ = storage.Store("abc001", file1.Name())
-			_ = storage.Store("abc002", file2.Name())
+			_ = storage.Store(ctx, "abc001", file1.Name())
+			_ = storage.Store(ctx, "abc002", file2.Name())
 
 			return []string{file1.Name(), file2.Name()}
 		}
@@ -33,28 +35,28 @@ func Test__Clear(t *testing.T) {
 		}
 
 		t.Run(fmt.Sprintf("%s no keys", storageType), func(t *testing.T) {
-			err := storage.Clear()
+			err := storage.Clear(ctx)
 			assert.Nil(t, err)
 
-			keys, err := storage.List()
+			keys, err := storage.List(ctx)
 			assert.Nil(t, err)
 			assert.Len(t, keys, 0)
 
-			err = storage.Clear()
+			err = storage.Clear(ctx)
 			assert.Nil(t, err)
 		})
 
 		t.Run(fmt.Sprintf("%s with keys", storageType), func(t *testing.T) {
 			filesToCleanup := setup(storage)
 
-			keys, err := storage.List()
+			keys, err := storage.List(ctx)
 			assert.Nil(t, err)
 			assert.Len(t, keys, 2)
 
-			err = storage.Clear()
+			err = storage.Clear(ctx)
 			assert.Nil(t, err)
 
-			keys, err = storage.List()
+			keys, err = storage.List(ctx)
 			assert.Nil(t, err)
 			assert.Len(t, keys, 0)
 

--- a/cache-cli/pkg/storage/delete_test.go
+++ b/cache-cli/pkg/storage/delete_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -10,27 +11,28 @@ import (
 )
 
 func Test__Delete(t *testing.T) {
+	ctx := context.TODO()
 	runTestForAllStorageTypes(t, SortByStoreTime, func(storageType string, storage Storage) {
 		t.Run(fmt.Sprintf("%s non-existing key", storageType), func(t *testing.T) {
-			_ = storage.Clear()
-			err := storage.Delete("this-key-does-not-exist")
+			_ = storage.Clear(ctx)
+			err := storage.Delete(ctx, "this-key-does-not-exist")
 			assert.Nil(t, err)
 		})
 
 		t.Run(fmt.Sprintf("%s existing key", storageType), func(t *testing.T) {
-			_ = storage.Clear()
+			_ = storage.Clear(ctx)
 
 			file, _ := ioutil.TempFile(os.TempDir(), "*")
-			_ = storage.Store("abc001", file.Name())
+			_ = storage.Store(ctx, "abc001", file.Name())
 
-			keys, err := storage.List()
+			keys, err := storage.List(ctx)
 			assert.Nil(t, err)
 			assert.Len(t, keys, 1)
 
-			err = storage.Delete("abc001")
+			err = storage.Delete(ctx, "abc001")
 			assert.Nil(t, err)
 
-			keys, err = storage.List()
+			keys, err = storage.List(ctx)
 			assert.Nil(t, err)
 			assert.Len(t, keys, 0)
 

--- a/cache-cli/pkg/storage/gcs.go
+++ b/cache-cli/pkg/storage/gcs.go
@@ -19,12 +19,12 @@ type GCSStorageOptions struct {
 	Config  StorageConfig
 }
 
-func NewGCSStorage(options GCSStorageOptions) (*GCSStorage, error) {
-	return createDefaultGCSStorage(options.Bucket, options.Project, options.Config)
+func NewGCSStorage(ctx context.Context, options GCSStorageOptions) (*GCSStorage, error) {
+	return createDefaultGCSStorage(ctx, options.Bucket, options.Project, options.Config)
 }
 
-func createDefaultGCSStorage(gcsBucket string, project string, storageConfig StorageConfig) (*GCSStorage, error) {
-	client, err := storage.NewClient(context.TODO())
+func createDefaultGCSStorage(ctx context.Context, gcsBucket string, project string, storageConfig StorageConfig) (*GCSStorage, error) {
+	client, err := storage.NewClient(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cache-cli/pkg/storage/gcs_clear.go
+++ b/cache-cli/pkg/storage/gcs_clear.go
@@ -7,8 +7,8 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-func (s *GCSStorage) Clear() error {
-	it := s.Bucket.Objects(context.TODO(), &storage.Query{Prefix: s.Project})
+func (s *GCSStorage) Clear(ctx context.Context) error {
+	it := s.Bucket.Objects(ctx, &storage.Query{Prefix: s.Project})
 	for {
 		attrs, err := it.Next()
 		if err == iterator.Done {
@@ -18,7 +18,7 @@ func (s *GCSStorage) Clear() error {
 			return err
 		}
 
-		err = s.Bucket.Object(attrs.Name).Delete(context.TODO())
+		err = s.Bucket.Object(attrs.Name).Delete(ctx)
 		if err != nil {
 			return err
 		}

--- a/cache-cli/pkg/storage/gcs_delete.go
+++ b/cache-cli/pkg/storage/gcs_delete.go
@@ -8,9 +8,9 @@ import (
 	gcs "cloud.google.com/go/storage"
 )
 
-func (s *GCSStorage) Delete(key string) error {
+func (s *GCSStorage) Delete(ctx context.Context, key string) error {
 	bucketKey := fmt.Sprintf("%s/%s", s.Project, key)
-	err := s.Bucket.Object(bucketKey).Delete(context.TODO())
+	err := s.Bucket.Object(bucketKey).Delete(ctx)
 	if errors.Is(err, gcs.ErrObjectNotExist) {
 		return nil
 	}

--- a/cache-cli/pkg/storage/gcs_has_key.go
+++ b/cache-cli/pkg/storage/gcs_has_key.go
@@ -8,9 +8,9 @@ import (
 	"cloud.google.com/go/storage"
 )
 
-func (s *GCSStorage) HasKey(key string) (bool, error) {
+func (s *GCSStorage) HasKey(ctx context.Context, key string) (bool, error) {
 	gcsKey := fmt.Sprintf("%s/%s", s.Project, key)
-	_, err := s.Bucket.Object(gcsKey).Attrs(context.TODO())
+	_, err := s.Bucket.Object(gcsKey).Attrs(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrObjectNotExist) {
 			return false, nil

--- a/cache-cli/pkg/storage/gcs_is_not_empty.go
+++ b/cache-cli/pkg/storage/gcs_is_not_empty.go
@@ -7,8 +7,8 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-func (s *GCSStorage) IsNotEmpty() (bool, error) {
-	it := s.Bucket.Objects(context.TODO(), &storage.Query{Prefix: s.Project})
+func (s *GCSStorage) IsNotEmpty(ctx context.Context) (bool, error) {
+	it := s.Bucket.Objects(ctx, &storage.Query{Prefix: s.Project})
 
 	_, err := it.Next()
 	if err == iterator.Done {

--- a/cache-cli/pkg/storage/gcs_list.go
+++ b/cache-cli/pkg/storage/gcs_list.go
@@ -10,8 +10,8 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-func (s *GCSStorage) List() ([]CacheKey, error) {
-	it := s.Bucket.Objects(context.TODO(), &storage.Query{Prefix: s.Project})
+func (s *GCSStorage) List(ctx context.Context) ([]CacheKey, error) {
+	it := s.Bucket.Objects(ctx, &storage.Query{Prefix: s.Project})
 
 	keys := make([]CacheKey, 0)
 	for {

--- a/cache-cli/pkg/storage/gcs_restore.go
+++ b/cache-cli/pkg/storage/gcs_restore.go
@@ -8,14 +8,14 @@ import (
 	"os"
 )
 
-func (s *GCSStorage) Restore(key string) (*os.File, error) {
+func (s *GCSStorage) Restore(ctx context.Context, key string) (*os.File, error) {
 	tempFile, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("%s-*", key))
 	if err != nil {
 		return nil, err
 	}
 
 	bucketKey := fmt.Sprintf("%s/%s", s.Project, key)
-	reader, err := s.Bucket.Object(bucketKey).NewReader(context.TODO())
+	reader, err := s.Bucket.Object(bucketKey).NewReader(ctx)
 	if err != nil {
 		_ = tempFile.Close()
 		return nil, err

--- a/cache-cli/pkg/storage/gcs_store.go
+++ b/cache-cli/pkg/storage/gcs_store.go
@@ -9,14 +9,14 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (s *GCSStorage) Store(key, path string) error {
+func (s *GCSStorage) Store(ctx context.Context, key, path string) error {
 	// #nosec
 	file, err := os.Open(path)
 	if err != nil {
 		return err
 	}
 
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	destination := fmt.Sprintf("%s/%s", s.Project, key)

--- a/cache-cli/pkg/storage/gcs_usage.go
+++ b/cache-cli/pkg/storage/gcs_usage.go
@@ -1,7 +1,9 @@
 package storage
 
-func (s *GCSStorage) Usage() (*UsageSummary, error) {
-	keys, err := s.List()
+import "context"
+
+func (s *GCSStorage) Usage(ctx context.Context) (*UsageSummary, error) {
+	keys, err := s.List(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cache-cli/pkg/storage/has_key_test.go
+++ b/cache-cli/pkg/storage/has_key_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -10,21 +11,22 @@ import (
 )
 
 func Test__HasKey(t *testing.T) {
+	ctx := context.TODO()
 	runTestForAllStorageTypes(t, SortByStoreTime, func(storageType string, storage Storage) {
 		t.Run(fmt.Sprintf("%s non-existing key", storageType), func(t *testing.T) {
-			_ = storage.Clear()
-			exists, err := storage.HasKey("this-key-does-not-exist")
+			_ = storage.Clear(ctx)
+			exists, err := storage.HasKey(ctx, "this-key-does-not-exist")
 			assert.Nil(t, err)
 			assert.False(t, exists)
 		})
 
 		t.Run(fmt.Sprintf("%s existing key", storageType), func(t *testing.T) {
-			_ = storage.Clear()
+			_ = storage.Clear(ctx)
 
 			file, _ := ioutil.TempFile(os.TempDir(), "*")
-			_ = storage.Store("abc001", file.Name())
+			_ = storage.Store(ctx, "abc001", file.Name())
 
-			exists, err := storage.HasKey("abc001")
+			exists, err := storage.HasKey(ctx, "abc001")
 			assert.Nil(t, err)
 			assert.True(t, exists)
 

--- a/cache-cli/pkg/storage/is_not_empty_test.go
+++ b/cache-cli/pkg/storage/is_not_empty_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -10,21 +11,22 @@ import (
 )
 
 func Test__IsNotEmpty(t *testing.T) {
+	ctx := context.TODO()
 	runTestForAllStorageTypes(t, SortByStoreTime, func(storageType string, storage Storage) {
 		t.Run(fmt.Sprintf("%s empty cache", storageType), func(t *testing.T) {
-			_ = storage.Clear()
-			isNotEmpty, err := storage.IsNotEmpty()
+			_ = storage.Clear(ctx)
+			isNotEmpty, err := storage.IsNotEmpty(ctx)
 			assert.Nil(t, err)
 			assert.False(t, isNotEmpty)
 		})
 
 		t.Run(fmt.Sprintf("%s non-empty cache", storageType), func(t *testing.T) {
-			_ = storage.Clear()
+			_ = storage.Clear(ctx)
 
 			file, _ := ioutil.TempFile(os.TempDir(), "*")
-			_ = storage.Store("abc001", file.Name())
+			_ = storage.Store(ctx, "abc001", file.Name())
 
-			isNotEmpty, err := storage.IsNotEmpty()
+			isNotEmpty, err := storage.IsNotEmpty(ctx)
 			assert.Nil(t, err)
 			assert.True(t, isNotEmpty)
 

--- a/cache-cli/pkg/storage/restore_test.go
+++ b/cache-cli/pkg/storage/restore_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -10,17 +11,18 @@ import (
 )
 
 func Test__Restore(t *testing.T) {
+	ctx := context.TODO()
 	runTestForAllStorageTypes(t, SortByStoreTime, func(storageType string, storage Storage) {
 		t.Run(fmt.Sprintf("%s key exists", storageType), func(t *testing.T) {
-			_ = storage.Clear()
+			_ = storage.Clear(ctx)
 
 			file, _ := ioutil.TempFile(os.TempDir(), "*")
 			file.WriteString("restore - key exists")
 
-			err := storage.Store("abc001", file.Name())
+			err := storage.Store(ctx, "abc001", file.Name())
 			assert.Nil(t, err)
 
-			restoredFile, err := storage.Restore("abc001")
+			restoredFile, err := storage.Restore(ctx, "abc001")
 			assert.Nil(t, err)
 
 			content, err := ioutil.ReadFile(restoredFile.Name())
@@ -32,9 +34,9 @@ func Test__Restore(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("%s key does not exist", storageType), func(t *testing.T) {
-			_ = storage.Clear()
+			_ = storage.Clear(ctx)
 
-			_, err := storage.Restore("abc002")
+			_, err := storage.Restore(ctx, "abc002")
 			assert.NotNil(t, err)
 		})
 	})

--- a/cache-cli/pkg/storage/s3_clear.go
+++ b/cache-cli/pkg/storage/s3_clear.go
@@ -8,8 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
-func (s *S3Storage) Clear() error {
-	keys, err := s.List()
+func (s *S3Storage) Clear(ctx context.Context) error {
+	keys, err := s.List(ctx)
 	if err != nil {
 		return err
 	}
@@ -22,7 +22,7 @@ func (s *S3Storage) Clear() error {
 	chunks := createChunks(keys, 1000)
 
 	for _, chunk := range chunks {
-		err := s.deleteChunk(chunk)
+		err := s.deleteChunk(ctx, chunk)
 		if err != nil {
 			return err
 		}
@@ -31,8 +31,8 @@ func (s *S3Storage) Clear() error {
 	return nil
 }
 
-func (s *S3Storage) deleteChunk(keys []CacheKey) error {
-	output, err := s.Client.DeleteObjects(context.TODO(), &s3.DeleteObjectsInput{
+func (s *S3Storage) deleteChunk(ctx context.Context, keys []CacheKey) error {
+	output, err := s.Client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
 		Bucket: &s.Bucket,
 		Delete: &types.Delete{
 			Objects: cacheKeysToObjectIdentifiers(s.Project, keys),

--- a/cache-cli/pkg/storage/s3_delete.go
+++ b/cache-cli/pkg/storage/s3_delete.go
@@ -7,10 +7,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
-func (s *S3Storage) Delete(key string) error {
+func (s *S3Storage) Delete(ctx context.Context, key string) error {
 	bucketKey := fmt.Sprintf("%s/%s", s.Project, key)
 
-	_, err := s.Client.DeleteObject(context.TODO(), &s3.DeleteObjectInput{
+	_, err := s.Client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: &s.Bucket,
 		Key:    &bucketKey,
 	})

--- a/cache-cli/pkg/storage/s3_has_key.go
+++ b/cache-cli/pkg/storage/s3_has_key.go
@@ -9,14 +9,14 @@ import (
 	"github.com/aws/smithy-go"
 )
 
-func (s *S3Storage) HasKey(key string) (bool, error) {
+func (s *S3Storage) HasKey(ctx context.Context, key string) (bool, error) {
 	s3Key := fmt.Sprintf("%s/%s", s.Project, key)
 	input := s3.HeadObjectInput{
 		Bucket: &s.Bucket,
 		Key:    &s3Key,
 	}
 
-	_, err := s.Client.HeadObject(context.TODO(), &input)
+	_, err := s.Client.HeadObject(ctx, &input)
 	if err != nil {
 		var apiErr *smithy.GenericAPIError
 		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "NotFound" {

--- a/cache-cli/pkg/storage/s3_is_not_empty.go
+++ b/cache-cli/pkg/storage/s3_is_not_empty.go
@@ -1,7 +1,9 @@
 package storage
 
-func (s *S3Storage) IsNotEmpty() (bool, error) {
-	keys, err := s.List()
+import "context"
+
+func (s *S3Storage) IsNotEmpty(ctx context.Context) (bool, error) {
+	keys, err := s.List(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/cache-cli/pkg/storage/s3_list.go
+++ b/cache-cli/pkg/storage/s3_list.go
@@ -10,8 +10,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
-func (s *S3Storage) List() ([]CacheKey, error) {
-	output, err := s.Client.ListObjects(context.TODO(), s.listObjectsInput(nil))
+func (s *S3Storage) List(ctx context.Context) ([]CacheKey, error) {
+	output, err := s.Client.ListObjects(ctx, s.listObjectsInput(nil))
 	if err != nil {
 		return nil, err
 	}
@@ -21,7 +21,7 @@ func (s *S3Storage) List() ([]CacheKey, error) {
 
 	for output.IsTruncated {
 		nextMarker := findNextMarker(output)
-		output, err = s.Client.ListObjects(context.TODO(), s.listObjectsInput(&nextMarker))
+		output, err = s.Client.ListObjects(ctx, s.listObjectsInput(&nextMarker))
 		if err != nil {
 			return nil, err
 		}

--- a/cache-cli/pkg/storage/s3_restore.go
+++ b/cache-cli/pkg/storage/s3_restore.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
-func (s *S3Storage) Restore(key string) (*os.File, error) {
+func (s *S3Storage) Restore(ctx context.Context, key string) (*os.File, error) {
 	tempFile, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("%s-*", key))
 	if err != nil {
 		return nil, err
@@ -18,7 +18,7 @@ func (s *S3Storage) Restore(key string) (*os.File, error) {
 
 	bucketKey := fmt.Sprintf("%s/%s", s.Project, key)
 	downloader := manager.NewDownloader(s.Client)
-	_, err = downloader.Download(context.TODO(), tempFile, &s3.GetObjectInput{
+	_, err = downloader.Download(ctx, tempFile, &s3.GetObjectInput{
 		Bucket: &s.Bucket,
 		Key:    &bucketKey,
 	})

--- a/cache-cli/pkg/storage/s3_store.go
+++ b/cache-cli/pkg/storage/s3_store.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (s *S3Storage) Store(key, path string) error {
+func (s *S3Storage) Store(ctx context.Context, key, path string) error {
 	// #nosec
 	file, err := os.Open(path)
 	if err != nil {
@@ -19,7 +19,7 @@ func (s *S3Storage) Store(key, path string) error {
 
 	destination := fmt.Sprintf("%s/%s", s.Project, key)
 	uploader := manager.NewUploader(s.Client)
-	_, err = uploader.Upload(context.TODO(), &s3.PutObjectInput{
+	_, err = uploader.Upload(ctx, &s3.PutObjectInput{
 		Bucket: &s.Bucket,
 		Key:    &destination,
 		Body:   file,

--- a/cache-cli/pkg/storage/s3_usage.go
+++ b/cache-cli/pkg/storage/s3_usage.go
@@ -1,7 +1,9 @@
 package storage
 
-func (s *S3Storage) Usage() (*UsageSummary, error) {
-	keys, err := s.List()
+import "context"
+
+func (s *S3Storage) Usage(ctx context.Context) (*UsageSummary, error) {
+	keys, err := s.List(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cache-cli/pkg/storage/sftp.go
+++ b/cache-cli/pkg/storage/sftp.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -24,7 +25,7 @@ type SFTPStorageOptions struct {
 	Config         StorageConfig
 }
 
-func NewSFTPStorage(options SFTPStorageOptions) (*SFTPStorage, error) {
+func NewSFTPStorage(ctx context.Context, options SFTPStorageOptions) (*SFTPStorage, error) {
 	sshClient, err := createSSHClient(options)
 	if err != nil {
 		return nil, err

--- a/cache-cli/pkg/storage/sftp_clear.go
+++ b/cache-cli/pkg/storage/sftp_clear.go
@@ -1,7 +1,9 @@
 package storage
 
-func (s *SFTPStorage) Clear() error {
-	keys, err := s.List()
+import "context"
+
+func (s *SFTPStorage) Clear(ctx context.Context) error {
+	keys, err := s.List(ctx)
 	if err != nil {
 		return err
 	}

--- a/cache-cli/pkg/storage/sftp_delete.go
+++ b/cache-cli/pkg/storage/sftp_delete.go
@@ -1,8 +1,11 @@
 package storage
 
-import "strings"
+import (
+	"context"
+	"strings"
+)
 
-func (s *SFTPStorage) Delete(key string) error {
+func (s *SFTPStorage) Delete(ctx context.Context, key string) error {
 	err := s.SFTPClient.Remove(key)
 	if err != nil && strings.Contains(err.Error(), "file does not exist") {
 		return nil

--- a/cache-cli/pkg/storage/sftp_has_key.go
+++ b/cache-cli/pkg/storage/sftp_has_key.go
@@ -1,8 +1,11 @@
 package storage
 
-import "strings"
+import (
+	"context"
+	"strings"
+)
 
-func (s *SFTPStorage) HasKey(key string) (bool, error) {
+func (s *SFTPStorage) HasKey(ctx context.Context, key string) (bool, error) {
 	file, err := s.SFTPClient.Stat(key)
 	if file == nil {
 		if err != nil && strings.Contains(err.Error(), "file does not exist") {

--- a/cache-cli/pkg/storage/sftp_is_not_empty.go
+++ b/cache-cli/pkg/storage/sftp_is_not_empty.go
@@ -1,7 +1,9 @@
 package storage
 
-func (s *SFTPStorage) IsNotEmpty() (bool, error) {
-	keys, err := s.List()
+import "context"
+
+func (s *SFTPStorage) IsNotEmpty(ctx context.Context) (bool, error) {
+	keys, err := s.List(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/cache-cli/pkg/storage/sftp_list.go
+++ b/cache-cli/pkg/storage/sftp_list.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"io/fs"
 	"sort"
 	"time"
@@ -8,7 +9,7 @@ import (
 	"github.com/pkg/sftp"
 )
 
-func (s *SFTPStorage) List() ([]CacheKey, error) {
+func (s *SFTPStorage) List(ctx context.Context) ([]CacheKey, error) {
 	files, err := s.SFTPClient.ReadDir(".")
 	if err != nil {
 		return nil, err

--- a/cache-cli/pkg/storage/sftp_restore.go
+++ b/cache-cli/pkg/storage/sftp_restore.go
@@ -1,12 +1,13 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
 )
 
-func (s *SFTPStorage) Restore(key string) (*os.File, error) {
+func (s *SFTPStorage) Restore(ctx context.Context, key string) (*os.File, error) {
 	localFile, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("%s-*", key))
 	if err != nil {
 		return nil, err

--- a/cache-cli/pkg/storage/sftp_usage.go
+++ b/cache-cli/pkg/storage/sftp_usage.go
@@ -1,6 +1,8 @@
 package storage
 
-func (s *SFTPStorage) Usage() (*UsageSummary, error) {
+import "context"
+
+func (s *SFTPStorage) Usage(ctx context.Context) (*UsageSummary, error) {
 	files, err := s.SFTPClient.ReadDir(".")
 	if err != nil {
 		return nil, err

--- a/cache-cli/pkg/storage/storage_test.go
+++ b/cache-cli/pkg/storage/storage_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"math"
 	"os"
 	"runtime"
@@ -18,7 +19,7 @@ var testStorageTypes = map[string]TestStorageType{
 	"s3": {
 		runInWindows: true,
 		initializer: func(storageSize int64, sortBy string) (Storage, error) {
-			return NewS3Storage(S3StorageOptions{
+			return NewS3Storage(context.TODO(), S3StorageOptions{
 				URL:     os.Getenv("SEMAPHORE_CACHE_S3_URL"),
 				Bucket:  "semaphore-cache",
 				Project: "cache-cli",
@@ -29,7 +30,7 @@ var testStorageTypes = map[string]TestStorageType{
 	"sftp": {
 		runInWindows: false,
 		initializer: func(storageSize int64, sortBy string) (Storage, error) {
-			return NewSFTPStorage(SFTPStorageOptions{
+			return NewSFTPStorage(context.TODO(), SFTPStorageOptions{
 				URL:            "sftp-server:22",
 				Username:       "tester",
 				PrivateKeyPath: "/root/.ssh/semaphore_cache_key",
@@ -40,7 +41,7 @@ var testStorageTypes = map[string]TestStorageType{
 	"gcs": {
 		runInWindows: false,
 		initializer: func(storageSize int64, sortBy string) (Storage, error) {
-			return NewGCSStorage(GCSStorageOptions{
+			return NewGCSStorage(context.TODO(), GCSStorageOptions{
 				Bucket:  "semaphore-cache",
 				Project: "cache-cli",
 				Config:  StorageConfig{MaxSpace: math.MaxInt64, SortKeysBy: sortBy},

--- a/cache-cli/pkg/storage/usage_test.go
+++ b/cache-cli/pkg/storage/usage_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -10,10 +11,11 @@ import (
 )
 
 func Test__Usage(t *testing.T) {
+	ctx := context.TODO()
 	runTestForAllStorageTypes(t, SortByStoreTime, func(storageType string, storage Storage) {
 		t.Run(fmt.Sprintf("%s no usage", storageType), func(t *testing.T) {
-			_ = storage.Clear()
-			usage, err := storage.Usage()
+			_ = storage.Clear(ctx)
+			usage, err := storage.Usage(ctx)
 			assert.Nil(t, err)
 			assert.Equal(t, int64(0), usage.Used)
 
@@ -26,14 +28,14 @@ func Test__Usage(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("%s some usage", storageType), func(t *testing.T) {
-			_ = storage.Clear()
+			_ = storage.Clear(ctx)
 
 			fileContents := "usage - some usage"
 			file, _ := ioutil.TempFile(os.TempDir(), "*")
 			file.WriteString(fileContents)
-			_ = storage.Store("abc001", file.Name())
+			_ = storage.Store(ctx, "abc001", file.Name())
 
-			usage, err := storage.Usage()
+			usage, err := storage.Usage(ctx)
 			assert.Nil(t, err)
 			assert.Equal(t, int64(len(fileContents)), usage.Used)
 


### PR DESCRIPTION
Adopt `context.Context` so operations can be halted by a interrupt signal