### PR TITLE
Supress printing error if failing to generate signed URLs 

### DIFF
--- a/sem-context/pkg/store/artifacts_store.go
+++ b/sem-context/pkg/store/artifacts_store.go
@@ -110,7 +110,8 @@ func (_ *ArtifactStore) CheckIfKeyDeleted(key, contextId string) (bool, error) {
 	}
 	defer os.RemoveAll(dir)
 
-	if output, err := execArtifactCommand(Pull, keysInfoDirName+contextId+"/.deleted/", dir); err != nil {
+	output, err := execArtifactCommand(Pull, keysInfoDirName+contextId+"/.deleted/", dir)
+	if err != nil && !strings.Contains(output, "failed to generate signed URL") {
 		log.Printf("error executing artifact command: %v. Output: %s\n", err, output)
 	}
 


### PR DESCRIPTION
In most cases it means file does not exist -> it means that key was not deleted and we can ignore that error.

task: https://github.com/renderedtext/tasks/issues/7117