### PR TITLE
feat: Add alias for Erlang 28.0, Alias version bump

### DIFF
--- a/sem-version
+++ b/sem-version
@@ -45,9 +45,9 @@ version::change_ruby() {
   [[ "$software_version" == "2.7" ]] && software_version="2.7.8"
   [[ "$software_version" == "3.0" ]] && software_version="3.0.7"
   [[ "$software_version" == "3.1" ]] && software_version="3.1.6"
-  [[ "$software_version" == "3.2" ]] && software_version="3.2.6"
-  [[ "$software_version" == "3.3" ]] && software_version="3.3.6"
-  [[ "$software_version" == "3.4" ]] && software_version="3.4.1"
+  [[ "$software_version" == "3.2" ]] && software_version="3.2.8"
+  [[ "$software_version" == "3.3" ]] && software_version="3.3.8"
+  [[ "$software_version" == "3.4" ]] && software_version="3.4.4"
 
   if ! [ -d ~/.rbenv/versions/"${software_version}" ]; then
     sem-install ruby "${software_version}"
@@ -73,8 +73,7 @@ version::change_elixir() {
   [[ "$software_version" == "1.15" ]] && software_version="1.15.8"
   [[ "$software_version" == "1.16" ]] && software_version="1.16.3"
   [[ "$software_version" == "1.17" ]] && software_version="1.17.3"
-  [[ "$software_version" == "1.18" ]] && software_version="1.18.0"
-
+  [[ "$software_version" == "1.18" ]] && software_version="1.18.4"
 
   if [[ $(kiex list) != *"${software_version}"* ]];then
     sem-install elixir "${software_version}"
@@ -136,7 +135,8 @@ version::change_erlang() {
   [[ "$software_version" == "24" ]] && software_version="24.3"
   [[ "$software_version" == "25" ]] && software_version="25.3"
   [[ "$software_version" == "26" ]] && software_version="26.2"
-  [[ "$software_version" == "27" ]] && software_version="27.2"
+  [[ "$software_version" == "27" ]] && software_version="27.3"
+  [[ "$software_version" == "28" ]] && software_version="28.0"
 
   if [[ $(kerl list installations) != *"${software_version}"* ]]; then
     sem-install erlang "${software_version}"

--- a/tests/sem_version_focal/elixir.bats
+++ b/tests/sem_version_focal/elixir.bats
@@ -90,8 +90,8 @@ setup() {
   assert_line --partial "Elixir 1.17.3"
 }
 
-@test "change elixir to 1.18.0" {
-  sem-version elixir 1.18.0
+@test "change elixir to 1.18.4" {
+  sem-version elixir 1.18.4
   run elixir --version
-  assert_line --partial "Elixir 1.18.0"
+  assert_line --partial "Elixir 1.18.4"
 }

--- a/tests/sem_version_focal/erlang.bats
+++ b/tests/sem_version_focal/erlang.bats
@@ -72,3 +72,15 @@ setup() {
   run erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().'  -noshell
   assert_line --partial "27"
 }
+
+@test "change erlang to 27.3" {
+  sem-version erlang 27.3
+  run erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().'  -noshell
+  assert_line --partial "27"
+}
+
+@test "change erlang to 28.0" {
+  sem-version erlang 28.0
+  run erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().'  -noshell
+  assert_line --partial "28"
+}

--- a/tests/sem_version_focal/ruby.bats
+++ b/tests/sem_version_focal/ruby.bats
@@ -52,6 +52,14 @@ setup() {
   assert_line --partial "ruby 3.3.0"
 }
 
+@test "change ruby to 3.4.4" {
+
+  run sem-version ruby 3.4.4
+  assert_success
+  run ruby --version
+  assert_line --partial "ruby 3.4.4"
+}
+
 @test "ruby minor versions test" {
 
   run sem-version ruby 2.7
@@ -72,17 +80,17 @@ setup() {
   run sem-version ruby 3.2
   assert_success
   run ruby --version
-  assert_line --partial "ruby 3.2.6"
+  assert_line --partial "ruby 3.2.8"
 
   run sem-version ruby 3.3
   assert_success
   run ruby --version
-  assert_line --partial "ruby 3.3.6"
+  assert_line --partial "ruby 3.3.8"
 
   run sem-version ruby 3.4
   assert_success
   run ruby --version
-  assert_line --partial "ruby 3.4.1"
+  assert_line --partial "ruby 3.4.4"
 }
 
 @test "change ruby to 4.0.1" {

--- a/tests/sem_version_jammy/elixir.bats
+++ b/tests/sem_version_jammy/elixir.bats
@@ -59,8 +59,8 @@ setup() {
   assert_line --partial "Elixir 1.17.3"
 }
 
-@test "change elixir to 1.18.0" {
-  sem-version elixir 1.18.0
+@test "change elixir to 1.18.4" {
+  sem-version elixir 1.18.4
   run elixir --version
-  assert_line --partial "Elixir 1.18.0"
+  assert_line --partial "Elixir 1.18.4"
 }

--- a/tests/sem_version_jammy/erlang.bats
+++ b/tests/sem_version_jammy/erlang.bats
@@ -82,3 +82,15 @@ setup() {
   run erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().'  -noshell
   assert_line --partial "27"
 }
+
+@test "change erlang to 27.3" {
+  sem-version erlang 27.3
+  run erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().'  -noshell
+  assert_line --partial "27"
+}
+
+@test "change erlang to 28.0" {
+  sem-version erlang 28.0
+  run erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().'  -noshell
+  assert_line --partial "28"
+}

--- a/tests/sem_version_jammy/ruby.bats
+++ b/tests/sem_version_jammy/ruby.bats
@@ -52,6 +52,14 @@ setup() {
   assert_line --partial "ruby 3.3.0"
 }
 
+@test "change ruby to 3.4.4" {
+
+  run sem-version ruby 3.4.4
+  assert_success
+  run ruby --version
+  assert_line --partial "ruby 3.4.4"
+}
+
 @test "ruby minor versions test" {
 
   run sem-version ruby 2.7
@@ -72,17 +80,17 @@ setup() {
   run sem-version ruby 3.2
   assert_success
   run ruby --version
-  assert_line --partial "ruby 3.2.6"
+  assert_line --partial "ruby 3.2.8"
 
   run sem-version ruby 3.3
   assert_success
   run ruby --version
-  assert_line --partial "ruby 3.3.6"
+  assert_line --partial "ruby 3.3.8"
 
   run sem-version ruby 3.4
   assert_success
   run ruby --version
-  assert_line --partial "ruby 3.4.1"
+  assert_line --partial "ruby 3.4.4"
 }
 
 @test "change ruby to 4.0.1" {

--- a/tests/sem_version_noble/elixir.bats
+++ b/tests/sem_version_noble/elixir.bats
@@ -59,8 +59,8 @@ setup() {
   assert_line --partial "Elixir 1.17.3"
 }
 
-@test "change elixir to 1.18.0" {
-  sem-version elixir 1.18.0
+@test "change elixir to 1.18.4" {
+  sem-version elixir 1.18.4
   run elixir --version
-  assert_line --partial "Elixir 1.18.0"
+  assert_line --partial "Elixir 1.18.4"
 }

--- a/tests/sem_version_noble/erlang.bats
+++ b/tests/sem_version_noble/erlang.bats
@@ -82,3 +82,15 @@ setup() {
   run erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().'  -noshell
   assert_line --partial "27"
 }
+
+@test "change erlang to 27.3" {
+  sem-version erlang 27.3
+  run erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().'  -noshell
+  assert_line --partial "27"
+}
+
+@test "change erlang to 28.0" {
+  sem-version erlang 28.0
+  run erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().'  -noshell
+  assert_line --partial "28"
+}

--- a/tests/sem_version_noble/ruby.bats
+++ b/tests/sem_version_noble/ruby.bats
@@ -52,6 +52,14 @@ setup() {
   assert_line --partial "ruby 3.3.0"
 }
 
+@test "change ruby to 3.4.4" {
+
+  run sem-version ruby 3.4.4
+  assert_success
+  run ruby --version
+  assert_line --partial "ruby 3.4.4"
+}
+
 @test "ruby minor versions test" {
 
   run sem-version ruby 2.7
@@ -72,17 +80,17 @@ setup() {
   run sem-version ruby 3.2
   assert_success
   run ruby --version
-  assert_line --partial "ruby 3.2.6"
+  assert_line --partial "ruby 3.2.8"
 
   run sem-version ruby 3.3
   assert_success
   run ruby --version
-  assert_line --partial "ruby 3.3.6"
+  assert_line --partial "ruby 3.3.8"
 
   run sem-version ruby 3.4
   assert_success
   run ruby --version
-  assert_line --partial "ruby 3.4.1"
+  assert_line --partial "ruby 3.4.4"
 }
 
 @test "change ruby to 4.0.1" {


### PR DESCRIPTION
- Add alias for Erlang 28.0
- Alias version bump
  - Erlang 27: `27.2` -> `27.3`
  - Elixir 1.18: `1.18.0` -> `1.18.4`
  - Ruby 3.2: `3.2.6` -> `3.2.8`
  - Ruby 3.3: `3.3.6` -> `3.3.8`
  - Ruby 3.4: `3.4.1` -> `3.4.4`