### PR TITLE
fix(ci pipeline): Removing tests since when CLI is not supported for ubuntu2404

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -828,7 +828,6 @@ blocks:
               values:
                 - tests/install_package.bats
                 - tests/artifacts.bats
-                - tests/compiler.bats
                 - tests/test-results.bats
                 - tests/enetwork.bats
                 - tests/sem-semantic-release.bats


### PR DESCRIPTION
The when CLI supports Erlang versions 24 -26, and the default Erlang version on the ubuntu2404 image is 27.
This is a known limitation that will be fixed in future versions of the when CLI and the toolbox.
Due to this the compiler test will fail on ubuntu2404, so this PR is removing them.