### PR TITLE
feat: Adapt system-metrics-collector to work on macOS

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -495,6 +495,7 @@ blocks:
       prologue:
         commands:
           - checkout
+          - brew untap homebrew/homebrew-cask-versions --force
           - brew update
           - brew upgrade ruby-build
           - artifact pull workflow bin/linux/amd64/cache -d cache-cli/bin/linux/amd64/cache

--- a/system-metrics-collector
+++ b/system-metrics-collector
@@ -21,17 +21,59 @@
 # Jobs that run for an hour collect around 120 log lines. This should be safe
 # and not introduce any performance of disk usage problems.
 #
-
+DIST=$(uname)
 SYSTEM_DISK_LOCATION="/"
 DOCKER_DISK_LOCATION="/$([ -d /var/lib/docker ] && echo 'var/lib/docker')"
 OUTPUT="/tmp/system-metrics"
 
+memFree(){
+  local mem_free=-1
+  if [ "$DIST" == "Linux" ]; then
+    mem_free=$(free | grep Mem | awk '{ printf("%6.2f%%\n", ($3/$2 * 100.0)) }')
+  fi
+  if [ "$DIST" == "Darwin" ]; then
+    mem_free=$(memory_pressure | grep 'percentage' | tr -d '%'|awk '{print 100-$NF"%"}')
+  fi
+  echo $mem_free
+}
+sharedMemory(){
+  local shared_mem
+  if [ "$DIST" == "Linux" ]; then
+    shared_mem=$(free -m | grep Mem | awk '{ print $5 }')
+  fi
+  if [ "$DIST" == "Darwin" ]; then
+    shared_mem=0
+  fi
+  echo $shared_mem
+}
+cpuUsage(){
+  local cpu_usage
+  if [ "$DIST" == "Linux" ]; then
+    cpu_usage=$(ps L | grep -q '%cpu' && ps -A -o %cpu 2>/dev/null | awk '{s+=$1} END {print s "%"}')
+  fi
+  if [ "$DIST" == "Darwin" ]; then
+    cpu_usage=$(top -i 1 -l 1 -stats CPU | grep CPU | grep idle |tr -d '%'| awk '{print 100-$7"%"}')
+  fi
+  echo $cpu_usage
+}
+diskUsage(){
+  local disk=$1
+  local disk_usage=-1
+  if [ "$DIST" == "Linux" ]; then
+    disk_usage=$(df "$disk" | sed 1d | awk '{ printf("%6.2f%%\n", ($3/$2 * 100.0)) }')
+  fi
+  if [ "$DIST" == "Darwin" ]; then
+    disk_usage=$(df / | sed 1d | awk '{print $5}')
+  fi
+  echo $disk_usage
+}
+
 while true; do
-  MEMORY=$(free | grep Mem | awk '{ printf("%6.2f%%\n", ($3/$2 * 100.0)) }')
-  SHARED_MEMORY=$(free -m | grep Mem | awk '{ print $5 }')
-  SYSTEM_DISK=$(df "$SYSTEM_DISK_LOCATION" | sed 1d | awk '{ printf("%6.2f%%\n", ($3/$2 * 100.0)) }')
-  DOCKER_DISK=$(df "$DOCKER_DISK_LOCATION" | sed 1d | awk '{ printf("%6.2f%%\n", ($3/$2 * 100.0)) }')
-  CPU_USAGE=$(ps L | grep -q '%cpu' && ps -A -o %cpu 2>/dev/null | awk '{s+=$1} END {print s "%"}')
+  MEMORY=$(memFree)
+  SHARED_MEMORY=$(sharedMemory)
+  SYSTEM_DISK=$(diskUsage "$SYSTEM_DISK_LOCATION")
+  DOCKER_DISK=$(diskUsage "$DOCKER_DISK_LOCATION")
+  CPU_USAGE=$(cpuUsage)
   echo "$(date) |  cpu:$CPU_USAGE,  mem:$MEMORY,  system_disk:$SYSTEM_DISK,  docker_disk:$DOCKER_DISK,  shared_memory: $SHARED_MEMORY M" >> $OUTPUT
   sleep 1
 done


### PR DESCRIPTION
The system-metrics-collector script was based on Linux, with Linux-specific commands.
This PR makes it run and report on macOS-based systems.