### PR TITLE
fix: Misc typos

### DIFF
--- a/install-package
+++ b/install-package
@@ -118,7 +118,7 @@ if install_packages;then
     echo ">> Finished successfully."
   fi
 else
-  echo ">> Errors have occured during package installation."
+  echo ">> Errors have occurred during package installation."
   exit 1
 fi
 

--- a/release/create.sh
+++ b/release/create.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 ARTIFACT_CLI_VERSION="v0.6.5"
 SPC_CLI_VERSION="v1.12.1"
 WHEN_CLI_VERSION="v1.2.1"
-# we include multiple when binaries for all suported Erlang versions
+# we include multiple when binaries for all supported Erlang versions
 # and configure the correct one based on Erlang version in the VM where toolbox is installed
 WHEN_BINARY_VERSION_1="when_otp_24"
 WHEN_BINARY_VERSION_2="when_otp_25"

--- a/retry
+++ b/retry
@@ -49,7 +49,7 @@ function retry_execution {
     # echo "$__result__";
 
     if [ $__result__ -eq "0" ]; then
-      exit 0; # command executed succesfully
+      exit 0; # command executed successfully
     else
       if [[ $__i__ == $__n__ ]]; then
         echo "[$__i__/$__n__] Execution Failed with exit status $__result__. No more retries."

--- a/sem-context/cmd/root.go
+++ b/sem-context/cmd/root.go
@@ -27,5 +27,5 @@ func Execute() {
 
 func init() {
 	Store = &store.ArtifactStore{}
-	RootCmd.PersistentFlags().BoolVar(&flags.IgnoreFailure, "ignore-failure", false, "Ignore if failure occures, and always return 0.")
+	RootCmd.PersistentFlags().BoolVar(&flags.IgnoreFailure, "ignore-failure", false, "Ignore if failure occurs, and always return 0.")
 }

--- a/sem-context/pkg/store/artifacts_store.go
+++ b/sem-context/pkg/store/artifacts_store.go
@@ -78,7 +78,7 @@ func (_ *ArtifactStore) Delete(key, contextId string) error {
 		log.Printf("error executing artifact command: %v. Output: %s\n", err, output)
 	}
 
-	// The key might be present in some of the parent pipline's context as well, but we cant delete them there, as they might be used by some other pipeline.
+	// The key might be present in some of the parent pipeline's context as well, but we cant delete them there, as they might be used by some other pipeline.
 	// We will just mark those keys as deleted inside this pipeline's context.
 	artifact_output, err := execArtifactCommand(Push, file.Name(), keysInfoDirName+contextId+"/.deleted/"+key)
 	if err != nil {

--- a/system-metrics-collector
+++ b/system-metrics-collector
@@ -4,7 +4,7 @@
 # Simple log system metrics collector. Polls the system state every 1s and
 # saves the result to /tmp/system-metrics.
 #
-# The simple nature of the script allows it to seemlesly run in any Linux based
+# The simple nature of the script allows it to seamlessly run in any Linux based
 # VM, Docker image, or on a MacVM host.
 #
 # The recommended way to start the script is to run it in the background.

--- a/test-results/pkg/parser/helpers.go
+++ b/test-results/pkg/parser/helpers.go
@@ -66,7 +66,7 @@ func ParseTime(s string) time.Duration {
 	return d
 }
 
-// ParseInt parsers string respresentation of integer to integer value
+// ParseInt parsers string representation of integer to integer value
 func ParseInt(s string) int {
 	i, err := strconv.Atoi(s)
 	if err != nil {

--- a/test-results/priv/parsers/stdout/in.xml
+++ b/test-results/priv/parsers/stdout/in.xml
@@ -6,7 +6,7 @@
       <failure message="Assertion with == failed">I've failed</failure>
     </testcase>
     <testcase name="trims stderr">
-      <system-err>assume-im-longerr</system-err>
+      <system-err>assume-im-longer</system-err>
       <failure message="Assertion with == failed">I've failed as well</failure>
     </testcase>
     <testcase name="trims stderr" system-out="assume-im-long-but-also-ive-succeeded"></testcase>

--- a/tests/artifacts.bats
+++ b/tests/artifacts.bats
@@ -7,7 +7,7 @@ setup() {
   echo "hello" > /tmp/unique-file-$SEMAPHORE_JOB_ID
 }
 
-@test "artifacts - uploading to proect level" {
+@test "artifacts - uploading to project level" {
   run artifact push project /tmp/unique-file-$SEMAPHORE_JOB_ID
   assert_success
 

--- a/tests/compiler.bats
+++ b/tests/compiler.bats
@@ -26,7 +26,7 @@ setup() {
   cd -
 }
 
-@test "compiler can evaluare change_in expressions" {
+@test "compiler can evaluate change_in expressions" {
   cd /tmp/test-repo-clone
 
   run spc evaluate change-in --input .semaphore/semaphore.yml --output .semaphore/semaphore.yml.compiler --logs .semaphore/semaphore.yml.logs


### PR DESCRIPTION
When searching for "change_in", saw `@test "compiler can evaluare change_in expressions" {` so making this PR off the back of that.

These are all in comments/tests/rare error messages so no big behavioural changes should result from this.