### PR TITLE
build: update when CLI to v1.3.0 - with support for OTP 27

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -835,6 +835,7 @@ blocks:
                 - tests/test-results.bats
                 - tests/enetwork.bats
                 - tests/sem-semantic-release.bats
+                - tests/compiler.bats
           commands:
             - source release/install_in_tests.sh
             - git submodule init && git submodule update

--- a/release/create.sh
+++ b/release/create.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 ARTIFACT_CLI_VERSION="v0.6.5"
 SPC_CLI_VERSION="v1.12.1"
-WHEN_CLI_VERSION="v1.2.1"
+WHEN_CLI_VERSION="v1.3.0"
 # we include multiple when binaries for all suported Erlang versions
 # and configure the correct one based on Erlang version in the VM where toolbox is installed
 WHEN_BINARY_VERSION_1="when_otp_24"

--- a/release/create.sh
+++ b/release/create.sh
@@ -10,6 +10,7 @@ WHEN_CLI_VERSION="v1.3.0"
 WHEN_BINARY_VERSION_1="when_otp_24"
 WHEN_BINARY_VERSION_2="when_otp_25"
 WHEN_BINARY_VERSION_3="when_otp_26"
+WHEN_BINARY_VERSION_4="when_otp_27"
 
 ARTIFACT_CLI_URL="https://github.com/semaphoreci/artifact/releases/download/$ARTIFACT_CLI_VERSION"
 SPC_CLI_URL="https://github.com/semaphoreci/spc/releases/download/$SPC_CLI_VERSION"
@@ -30,6 +31,10 @@ download_when_cli() {
   echo "Downloading when CLI binary $WHEN_BINARY_VERSION_3"
   curl -sL --retry 5 $WHEN_CLI_URL/$WHEN_BINARY_VERSION_3 -o /tmp/when-cli/$WHEN_BINARY_VERSION_3
   chmod +x /tmp/when-cli/$WHEN_BINARY_VERSION_3
+
+  echo "Downloading when CLI binary $WHEN_BINARY_VERSION_4"
+  curl -sL --retry 5 $WHEN_CLI_URL/$WHEN_BINARY_VERSION_4 -o /tmp/when-cli/$WHEN_BINARY_VERSION_4
+  chmod +x /tmp/when-cli/$WHEN_BINARY_VERSION_4
 }
 
 create_tarball() {
@@ -187,10 +192,12 @@ self_hosted::pack() {
   cp /tmp/when-cli/$WHEN_BINARY_VERSION_1 /tmp/self-hosted-Linux/toolbox/$WHEN_BINARY_VERSION_1
   cp /tmp/when-cli/$WHEN_BINARY_VERSION_2 /tmp/self-hosted-Linux/toolbox/$WHEN_BINARY_VERSION_2
   cp /tmp/when-cli/$WHEN_BINARY_VERSION_3 /tmp/self-hosted-Linux/toolbox/$WHEN_BINARY_VERSION_3
+  cp /tmp/when-cli/$WHEN_BINARY_VERSION_4 /tmp/self-hosted-Linux/toolbox/$WHEN_BINARY_VERSION_4
 
   cp /tmp/when-cli/$WHEN_BINARY_VERSION_1 /tmp/self-hosted-Linux-arm/toolbox/$WHEN_BINARY_VERSION_1
   cp /tmp/when-cli/$WHEN_BINARY_VERSION_2 /tmp/self-hosted-Linux-arm/toolbox/$WHEN_BINARY_VERSION_2
   cp /tmp/when-cli/$WHEN_BINARY_VERSION_3 /tmp/self-hosted-Linux-arm/toolbox/$WHEN_BINARY_VERSION_3
+  cp /tmp/when-cli/$WHEN_BINARY_VERSION_4 /tmp/self-hosted-Linux-arm/toolbox/$WHEN_BINARY_VERSION_4
 
   cp ~/$SEMAPHORE_GIT_DIR/cache-cli/bin/linux/amd64/cache /tmp/self-hosted-Linux/toolbox/
   cp ~/$SEMAPHORE_GIT_DIR/cache-cli/bin/linux/arm64/cache /tmp/self-hosted-Linux-arm/toolbox/
@@ -232,9 +239,11 @@ hosted::pack() {
   cp /tmp/when-cli/$WHEN_BINARY_VERSION_1 /tmp/Linux/toolbox/$WHEN_BINARY_VERSION_1
   cp /tmp/when-cli/$WHEN_BINARY_VERSION_2 /tmp/Linux/toolbox/$WHEN_BINARY_VERSION_2
   cp /tmp/when-cli/$WHEN_BINARY_VERSION_3 /tmp/Linux/toolbox/$WHEN_BINARY_VERSION_3
+  cp /tmp/when-cli/$WHEN_BINARY_VERSION_4 /tmp/Linux/toolbox/$WHEN_BINARY_VERSION_4
   cp /tmp/when-cli/$WHEN_BINARY_VERSION_1 /tmp/Linux-arm/toolbox/$WHEN_BINARY_VERSION_1
   cp /tmp/when-cli/$WHEN_BINARY_VERSION_2 /tmp/Linux-arm/toolbox/$WHEN_BINARY_VERSION_2
   cp /tmp/when-cli/$WHEN_BINARY_VERSION_3 /tmp/Linux-arm/toolbox/$WHEN_BINARY_VERSION_3
+  cp /tmp/when-cli/$WHEN_BINARY_VERSION_4 /tmp/Linux-arm/toolbox/$WHEN_BINARY_VERSION_4
 }
 
 create_self_hosted=false


### PR DESCRIPTION
When [CLI v1.3.0](https://github.com/renderedtext/when/releases/tag/v1.3.0) was released and now it support OTP 27.

Also enables compiler tests on Ubuntu 24.04.

Related [task](https://github.com/renderedtext/tasks/issues/6609) and also [this one](https://github.com/renderedtext/tasks/issues/8303).