### PR TITLE
Add artifact CLI summary to test result operations

### DIFF
--- a/test-results/cmd/gen-pipeline-report.go
+++ b/test-results/cmd/gen-pipeline-report.go
@@ -112,7 +112,7 @@ var genPipelineReportCmd = &cobra.Command{
 			return err
 		}
 
-		displayTransferSummary(pullStats, pushStats)
+		cli.DisplayTransferSummary(pullStats, pushStats)
 
 		return nil
 	},
@@ -156,47 +156,6 @@ func pushSummariesWithStats(testResult []parser.TestResults, level, path string,
 		pushStats.TotalSize += stats.TotalSize
 	}
 	return nil
-}
-
-func displayTransferSummary(pullStats *cli.ArtifactStats, pushStats *cli.ArtifactStats) {
-	totalOps := pullStats.Operations + pushStats.Operations
-	if totalOps > 0 {
-		logger.Info("[test-results] Artifact transfers:")
-		
-		if pullStats.Operations > 0 {
-			if pullStats.FileCount > 0 || pullStats.TotalSize > 0 {
-				logger.Info("  → Pulled: %d operation%s, %d files, %s", 
-					pullStats.Operations, pluralize(pullStats.Operations), pullStats.FileCount, cli.FormatBytes(pullStats.TotalSize))
-			} else {
-				logger.Info("  → Pulled: %d operation%s", pullStats.Operations, pluralize(pullStats.Operations))
-			}
-		}
-		
-		if pushStats.Operations > 0 {
-			if pushStats.FileCount > 0 || pushStats.TotalSize > 0 {
-				logger.Info("  ← Pushed: %d operation%s, %d files, %s", 
-					pushStats.Operations, pluralize(pushStats.Operations), pushStats.FileCount, cli.FormatBytes(pushStats.TotalSize))
-			} else {
-				logger.Info("  ← Pushed: %d operation%s", pushStats.Operations, pluralize(pushStats.Operations))
-			}
-		}
-		
-		totalFiles := pullStats.FileCount + pushStats.FileCount
-		totalSize := pullStats.TotalSize + pushStats.TotalSize
-		if totalFiles > 0 || totalSize > 0 {
-			logger.Info("  = Total: %d operation%s, %d files, %s", 
-				totalOps, pluralize(totalOps), totalFiles, cli.FormatBytes(totalSize))
-		} else {
-			logger.Info("  = Total: %d operation%s", totalOps, pluralize(totalOps))
-		}
-	}
-}
-
-func pluralize(count int) string {
-	if count == 1 {
-		return ""
-	}
-	return "s"
 }
 
 func init() {

--- a/test-results/cmd/gen-pipeline-report.go
+++ b/test-results/cmd/gen-pipeline-report.go
@@ -161,37 +161,42 @@ func pushSummariesWithStats(testResult []parser.TestResults, level, path string,
 func displayTransferSummary(pullStats *cli.ArtifactStats, pushStats *cli.ArtifactStats) {
 	totalOps := pullStats.Operations + pushStats.Operations
 	if totalOps > 0 {
-		logger.Info("")
-		logger.Info("========================================")
-		logger.Info("test-results: Artifact Transfer Summary")
-		logger.Info("========================================")
+		logger.Info("[test-results] Artifact transfers:")
 		
 		if pullStats.Operations > 0 {
 			if pullStats.FileCount > 0 || pullStats.TotalSize > 0 {
-				logger.Info("Pull operations: %d (%d files, %s)", pullStats.Operations, pullStats.FileCount, cli.FormatBytes(pullStats.TotalSize))
+				logger.Info("  → Pulled: %d operation%s, %d files, %s", 
+					pullStats.Operations, pluralize(pullStats.Operations), pullStats.FileCount, cli.FormatBytes(pullStats.TotalSize))
 			} else {
-				logger.Info("Pull operations: %d", pullStats.Operations)
+				logger.Info("  → Pulled: %d operation%s", pullStats.Operations, pluralize(pullStats.Operations))
 			}
 		}
 		
 		if pushStats.Operations > 0 {
 			if pushStats.FileCount > 0 || pushStats.TotalSize > 0 {
-				logger.Info("Push operations: %d (%d files, %s)", pushStats.Operations, pushStats.FileCount, cli.FormatBytes(pushStats.TotalSize))
+				logger.Info("  ← Pushed: %d operation%s, %d files, %s", 
+					pushStats.Operations, pluralize(pushStats.Operations), pushStats.FileCount, cli.FormatBytes(pushStats.TotalSize))
 			} else {
-				logger.Info("Push operations: %d", pushStats.Operations)
+				logger.Info("  ← Pushed: %d operation%s", pushStats.Operations, pluralize(pushStats.Operations))
 			}
 		}
 		
 		totalFiles := pullStats.FileCount + pushStats.FileCount
 		totalSize := pullStats.TotalSize + pushStats.TotalSize
 		if totalFiles > 0 || totalSize > 0 {
-			logger.Info("Total: %d operations (%d files, %s)", totalOps, totalFiles, cli.FormatBytes(totalSize))
+			logger.Info("  = Total: %d operation%s, %d files, %s", 
+				totalOps, pluralize(totalOps), totalFiles, cli.FormatBytes(totalSize))
 		} else {
-			logger.Info("Total: %d operations", totalOps)
+			logger.Info("  = Total: %d operation%s", totalOps, pluralize(totalOps))
 		}
-		
-		logger.Info("========================================")
 	}
+}
+
+func pluralize(count int) string {
+	if count == 1 {
+		return ""
+	}
+	return "s"
 }
 
 func init() {

--- a/test-results/cmd/publish.go
+++ b/test-results/cmd/publish.go
@@ -181,7 +181,8 @@ var publishCmd = &cobra.Command{
 			}
 		}
 
-		displayPushSummary(pushStats)
+		emptyPullStats := &cli.ArtifactStats{}
+		cli.DisplayTransferSummary(emptyPullStats, pushStats)
 
 		return nil
 	},
@@ -225,17 +226,6 @@ func pushSummaryWithStats(testResult []parser.TestResults, level, path string, c
 		pushStats.TotalSize += stats.TotalSize
 	}
 	return nil
-}
-
-func displayPushSummary(stats *cli.ArtifactStats) {
-	if stats.Operations > 0 {
-		if stats.FileCount > 0 || stats.TotalSize > 0 {
-			logger.Info("[test-results] Artifacts pushed: %d operations, %d files, %s", 
-				stats.Operations, stats.FileCount, cli.FormatBytes(stats.TotalSize))
-		} else {
-			logger.Info("[test-results] Artifacts pushed: %d operations", stats.Operations)
-		}
-	}
 }
 
 func init() {

--- a/test-results/cmd/publish.go
+++ b/test-results/cmd/publish.go
@@ -229,18 +229,12 @@ func pushSummaryWithStats(testResult []parser.TestResults, level, path string, c
 
 func displayPushSummary(stats *cli.ArtifactStats) {
 	if stats.Operations > 0 {
-		logger.Info("")
-		logger.Info("========================================")
-		logger.Info("test-results: Artifact Push Summary")
-		logger.Info("========================================")
-		
 		if stats.FileCount > 0 || stats.TotalSize > 0 {
-			logger.Info("Push operations: %d (%d files, %s)", stats.Operations, stats.FileCount, cli.FormatBytes(stats.TotalSize))
+			logger.Info("[test-results] Artifacts pushed: %d operations, %d files, %s", 
+				stats.Operations, stats.FileCount, cli.FormatBytes(stats.TotalSize))
 		} else {
-			logger.Info("Push operations: %d", stats.Operations)
+			logger.Info("[test-results] Artifacts pushed: %d operations", stats.Operations)
 		}
-		
-		logger.Info("========================================")
 	}
 }
 

--- a/test-results/cmd/publish.go
+++ b/test-results/cmd/publish.go
@@ -64,7 +64,7 @@ var publishCmd = &cobra.Command{
 		defer os.RemoveAll(dirPath)
 
 		totalStats := &cli.ArtifactStats{}
-		uploadCount := 0
+		pushCount := 0
 
 		for _, path := range paths {
 			parser, err := cli.FindParser(path, cmd)
@@ -123,10 +123,10 @@ var publishCmd = &cobra.Command{
 		if stats != nil {
 			totalStats.FileCount += stats.FileCount
 			totalStats.TotalSize += stats.TotalSize
-			uploadCount++
+			pushCount++
 		}
 
-		if err = pushSummaryWithStats(result.TestResults, "job", path.Join("test-results", "summary.json"), cmd, totalStats, &uploadCount); err != nil {
+		if err = pushSummaryWithStats(result.TestResults, "job", path.Join("test-results", "summary.json"), cmd, totalStats, &pushCount); err != nil {
 			return err
 		}
 
@@ -149,7 +149,7 @@ var publishCmd = &cobra.Command{
 		if stats != nil {
 			totalStats.FileCount += stats.FileCount
 			totalStats.TotalSize += stats.TotalSize
-			uploadCount++
+			pushCount++
 		}
 
 		noRaw, err := cmd.Flags().GetBool("no-raw")
@@ -177,18 +177,18 @@ var publishCmd = &cobra.Command{
 				if stats != nil {
 					totalStats.FileCount += stats.FileCount
 					totalStats.TotalSize += stats.TotalSize
-					uploadCount++
+					pushCount++
 				}
 			}
 		}
 
-		displayUploadSummary(uploadCount, totalStats)
+		displayPushSummary(pushCount, totalStats)
 
 		return nil
 	},
 }
 
-func pushSummaryWithStats(testResult []parser.TestResults, level, path string, cmd *cobra.Command, totalStats *cli.ArtifactStats, uploadCount *int) error {
+func pushSummaryWithStats(testResult []parser.TestResults, level, path string, cmd *cobra.Command, totalStats *cli.ArtifactStats, pushCount *int) error {
 	skipCompression, err := cmd.Flags().GetBool("no-compress")
 	if err != nil {
 		return err
@@ -223,25 +223,24 @@ func pushSummaryWithStats(testResult []parser.TestResults, level, path string, c
 	if stats != nil {
 		totalStats.FileCount += stats.FileCount
 		totalStats.TotalSize += stats.TotalSize
-		*uploadCount++
+		*pushCount++
 	}
 	return nil
 }
 
-func displayUploadSummary(uploadCount int, stats *cli.ArtifactStats) {
-	if uploadCount > 0 {
+func displayPushSummary(pushCount int, stats *cli.ArtifactStats) {
+	if pushCount > 0 {
 		logger.Info("")
 		logger.Info("========================================")
-		logger.Info("Artifact Upload Summary")
+		logger.Info("test-results: Artifact Push Summary")
 		logger.Info("========================================")
-		logger.Info("Upload operations: %d", uploadCount)
 		
 		if stats.FileCount > 0 || stats.TotalSize > 0 {
-			logger.Info("Files uploaded: %d", stats.FileCount)
-			logger.Info("Total size: %s", cli.FormatBytes(stats.TotalSize))
+			logger.Info("Push operations: %d (%d files, %s)", pushCount, stats.FileCount, cli.FormatBytes(stats.TotalSize))
 		} else {
-			logger.Info("Uploads completed successfully")
+			logger.Info("Push operations: %d", pushCount)
 		}
+		
 		logger.Info("========================================")
 	}
 }

--- a/test-results/cmd/root.go
+++ b/test-results/cmd/root.go
@@ -83,7 +83,6 @@ func initConfig() {
 
 	viper.AutomaticEnv() // read in environment variables that match
 
-	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
 	}

--- a/test-results/pkg/cli/cli.go
+++ b/test-results/pkg/cli/cli.go
@@ -550,3 +550,53 @@ func FormatBytes(bytes int64) string {
 	}
 	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
 }
+
+func Pluralize(count int, singular string, plural string) string {
+	if count == 1 {
+		return singular
+	}
+	return plural
+}
+
+func DisplayTransferSummary(pullStats *ArtifactStats, pushStats *ArtifactStats) {
+	totalOps := pullStats.Operations + pushStats.Operations
+	if totalOps > 0 {
+		logger.Info("[test-results] Artifact transfers:")
+		
+		if pullStats.Operations > 0 {
+			if pullStats.FileCount > 0 || pullStats.TotalSize > 0 {
+				logger.Info("  → Pulled: %d %s, %d %s, %s", 
+					pullStats.Operations, Pluralize(pullStats.Operations, "operation", "operations"),
+					pullStats.FileCount, Pluralize(pullStats.FileCount, "file", "files"),
+					FormatBytes(pullStats.TotalSize))
+			} else {
+				logger.Info("  → Pulled: %d %s", 
+					pullStats.Operations, Pluralize(pullStats.Operations, "operation", "operations"))
+			}
+		}
+		
+		if pushStats.Operations > 0 {
+			if pushStats.FileCount > 0 || pushStats.TotalSize > 0 {
+				logger.Info("  ← Pushed: %d %s, %d %s, %s", 
+					pushStats.Operations, Pluralize(pushStats.Operations, "operation", "operations"),
+					pushStats.FileCount, Pluralize(pushStats.FileCount, "file", "files"),
+					FormatBytes(pushStats.TotalSize))
+			} else {
+				logger.Info("  ← Pushed: %d %s", 
+					pushStats.Operations, Pluralize(pushStats.Operations, "operation", "operations"))
+			}
+		}
+		
+		totalFiles := pullStats.FileCount + pushStats.FileCount
+		totalSize := pullStats.TotalSize + pushStats.TotalSize
+		if totalFiles > 0 || totalSize > 0 {
+			logger.Info("  = Total: %d %s, %d %s, %s", 
+				totalOps, Pluralize(totalOps, "operation", "operations"),
+				totalFiles, Pluralize(totalFiles, "file", "files"),
+				FormatBytes(totalSize))
+		} else {
+			logger.Info("  = Total: %d %s", 
+				totalOps, Pluralize(totalOps, "operation", "operations"))
+		}
+	}
+}

--- a/test-results/pkg/cli/cli.go
+++ b/test-results/pkg/cli/cli.go
@@ -24,8 +24,9 @@ import (
 )
 
 type ArtifactStats struct {
-	FileCount int
-	TotalSize int64
+	Operations int
+	FileCount  int
+	TotalSize  int64
 }
 
 // LoadFiles checks if path exists and can be `stat`ed at given `path`

--- a/test-results/pkg/cli/cli_stats_test.go
+++ b/test-results/pkg/cli/cli_stats_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"testing"
+)
+
+func TestParseArtifactStats(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   string
+		expected ArtifactStats
+	}{
+		{
+			name: "modern push format",
+			output: `[2024-01-15 10:30:45.123] Successfully pushed artifact for current job.
+[2024-01-15 10:30:45.124] * Local source: /tmp/test-results123.
+[2024-01-15 10:30:45.125] * Remote destination: test-results/junit.json.
+[2024-01-15 10:30:45.126] Pushed 3 files. Total of 1.5 MB`,
+			expected: ArtifactStats{
+				FileCount: 3,
+				TotalSize: 1572864, // 1.5 * 1024 * 1024
+			},
+		},
+		{
+			name: "modern pull format",
+			output: `[2024-01-15 10:30:45.123] Successfully pulled artifact.
+[2024-01-15 10:30:45.126] Pulled 5 files. Total of 2.3 GB`,
+			expected: ArtifactStats{
+				FileCount: 5,
+				TotalSize: 2469606195, // 2.3 * 1024 * 1024 * 1024
+			},
+		},
+		{
+			name: "single file",
+			output: `[2024-01-15 10:30:45.126] Pushed 1 file. Total of 512 KB`,
+			expected: ArtifactStats{
+				FileCount: 1,
+				TotalSize: 524288, // 512 * 1024
+			},
+		},
+		{
+			name: "bytes only",
+			output: `[2024-01-15 10:30:45.126] Pushed 2 files. Total of 1024 B`,
+			expected: ArtifactStats{
+				FileCount: 2,
+				TotalSize: 1024,
+			},
+		},
+		{
+			name:     "old format or no stats",
+			output:   `Successfully pushed artifact`,
+			expected: ArtifactStats{},
+		},
+		{
+			name:     "empty output",
+			output:   "",
+			expected: ArtifactStats{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseArtifactStats(tt.output)
+			if result.FileCount != tt.expected.FileCount {
+				t.Errorf("FileCount: got %d, want %d", result.FileCount, tt.expected.FileCount)
+			}
+			// Allow small difference due to float precision
+			sizeDiff := result.TotalSize - tt.expected.TotalSize
+			if sizeDiff < 0 {
+				sizeDiff = -sizeDiff
+			}
+			if sizeDiff > 10 {
+				t.Errorf("TotalSize: got %d, want %d", result.TotalSize, tt.expected.TotalSize)
+			}
+		})
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		bytes    int64
+		expected string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+		{1572864, "1.5 MB"},
+		{1073741824, "1.0 GB"},
+		{10737418240, "10.0 GB"},
+	}
+
+	for _, tt := range tests {
+		result := FormatBytes(tt.bytes)
+		if result != tt.expected {
+			t.Errorf("FormatBytes(%d): got %s, want %s", tt.bytes, result, tt.expected)
+		}
+	}
+}

--- a/tests/test-results.bats
+++ b/tests/test-results.bats
@@ -36,11 +36,12 @@ setup() {
 
 teardown() {
   rm -rf /tmp/test-results-cli
-}
-
-teardown_file() {
-  artifact yank job test-results
-  artifact yank workflow test-results/$SEMAPHORE_PIPELINE_ID/$SEMAPHORE_JOB_ID.json
+  
+  # Clean up artifacts to avoid conflicts in subsequent test runs
+  artifact yank job test-results 2>/dev/null || true
+  artifact yank workflow test-results/$SEMAPHORE_PIPELINE_ID/$SEMAPHORE_JOB_ID.json 2>/dev/null || true
+  artifact yank workflow test-results/$SEMAPHORE_PIPELINE_ID.json 2>/dev/null || true
+  artifact yank workflow test-results/$SEMAPHORE_PIPELINE_ID-summary.json 2>/dev/null || true
 }
 
 @test "test-results publish works" {
@@ -97,9 +98,6 @@ teardown_file() {
   
   assert_output --partial "test-results: Artifact Push Summary"
   assert_output --regexp "Push operations: 3"
-  
-  artifact yank job test-results
-  artifact yank workflow test-results/$SEMAPHORE_PIPELINE_ID/$SEMAPHORE_JOB_ID.json
 }
 
 @test "test-results publish multiple files shows correct operation count" {
@@ -111,9 +109,6 @@ teardown_file() {
   
   assert_output --partial "test-results: Artifact Push Summary"
   assert_output --regexp "Push operations: 5"
-  
-  artifact yank job test-results
-  artifact yank workflow test-results/$SEMAPHORE_PIPELINE_ID/$SEMAPHORE_JOB_ID.json
 }
 
 @test "test-results gen-pipeline-report shows transfer summary" {
@@ -128,9 +123,4 @@ teardown_file() {
   assert_output --partial "test-results: Artifact Transfer Summary"
   assert_output --regexp "(Pull|Push) operations:"
   assert_output --partial "Total:"
-  
-  artifact yank job test-results
-  artifact yank workflow test-results/$SEMAPHORE_PIPELINE_ID.json
-  artifact yank workflow test-results/$SEMAPHORE_PIPELINE_ID-summary.json
-  artifact yank workflow test-results/$SEMAPHORE_PIPELINE_ID/$SEMAPHORE_JOB_ID.json
 }

--- a/tests/test-results.bats
+++ b/tests/test-results.bats
@@ -50,7 +50,9 @@ teardown() {
   run test-results publish --no-compress junit-sample.xml
   assert_success
 
-  assert_output --partial "[test-results] Artifacts pushed: 4 operations"
+  assert_output --partial "[test-results] Artifact transfers:"
+  assert_output --partial "← Pushed: 4 operations"
+  assert_output --partial "= Total: 4 operations"
 
   run artifact pull job test-results/junit.xml
   assert_success

--- a/tests/test-results.bats
+++ b/tests/test-results.bats
@@ -97,7 +97,9 @@ teardown() {
   run test-results publish --no-compress --no-raw junit-sample.xml
   assert_success
 
-  assert_output --partial "[test-results] Artifacts pushed: 3 operations"
+  assert_output --partial "[test-results] Artifact transfers:"
+  assert_output --partial "← Pushed: 3 operations"
+  assert_output --partial "= Total: 3 operations"
 }
 
 @test "test-results publish multiple files shows correct operation count" {
@@ -107,7 +109,9 @@ teardown() {
   run test-results publish --no-compress junit-sample.xml junit-sample2.xml
   assert_success
 
-  assert_output --partial "[test-results] Artifacts pushed: 5 operations"
+  assert_output --partial "[test-results] Artifact transfers:"
+  assert_output --partial "← Pushed: 5 operations"
+  assert_output --partial "= Total: 5 operations"
 }
 
 @test "test-results gen-pipeline-report shows transfer summary" {

--- a/tests/test-results.bats
+++ b/tests/test-results.bats
@@ -36,7 +36,7 @@ setup() {
 
 teardown() {
   rm -rf /tmp/test-results-cli
-  
+
   # Clean up artifacts to avoid conflicts in subsequent test runs
   artifact yank job test-results 2>/dev/null || true
   artifact yank workflow test-results/$SEMAPHORE_PIPELINE_ID/$SEMAPHORE_JOB_ID.json 2>/dev/null || true
@@ -49,7 +49,7 @@ teardown() {
 
   run test-results publish --no-compress junit-sample.xml
   assert_success
-  
+
   assert_output --partial "[test-results] Artifacts pushed: 4 operations"
 
   run artifact pull job test-results/junit.xml
@@ -91,33 +91,36 @@ teardown() {
 
 @test "test-results publish with --no-raw shows correct operation count" {
   cd /tmp/test-results-cli
-  
+
   run test-results publish --no-compress --no-raw junit-sample.xml
   assert_success
-  
+
   assert_output --partial "[test-results] Artifacts pushed: 3 operations"
 }
 
 @test "test-results publish multiple files shows correct operation count" {
   cd /tmp/test-results-cli
   cp junit-sample.xml junit-sample2.xml
-  
+
   run test-results publish --no-compress junit-sample.xml junit-sample2.xml
   assert_success
-  
+
   assert_output --partial "[test-results] Artifacts pushed: 5 operations"
 }
 
 @test "test-results gen-pipeline-report shows transfer summary" {
   cd /tmp/test-results-cli
-  
+
   run test-results publish --no-compress junit-sample.xml
   assert_success
-  
-  run test-results gen-pipeline-report
+
+  mkdir -p pipeline-results
+  cp junit-sample.json pipeline-results/
+
+  run test-results gen-pipeline-report --force pipeline-results
   assert_success
-  
+
   assert_output --partial "[test-results] Artifact transfers:"
-  assert_output --regexp "(Pulled|Pushed):"
+  assert_output --partial "← Pushed:"
   assert_output --partial "= Total:"
 }

--- a/tests/test-results.bats
+++ b/tests/test-results.bats
@@ -50,8 +50,7 @@ teardown() {
   run test-results publish --no-compress junit-sample.xml
   assert_success
   
-  assert_output --partial "test-results: Artifact Push Summary"
-  assert_output --regexp "Push operations: 4"
+  assert_output --partial "[test-results] Artifacts pushed: 4 operations"
 
   run artifact pull job test-results/junit.xml
   assert_success
@@ -96,8 +95,7 @@ teardown() {
   run test-results publish --no-compress --no-raw junit-sample.xml
   assert_success
   
-  assert_output --partial "test-results: Artifact Push Summary"
-  assert_output --regexp "Push operations: 3"
+  assert_output --partial "[test-results] Artifacts pushed: 3 operations"
 }
 
 @test "test-results publish multiple files shows correct operation count" {
@@ -107,8 +105,7 @@ teardown() {
   run test-results publish --no-compress junit-sample.xml junit-sample2.xml
   assert_success
   
-  assert_output --partial "test-results: Artifact Push Summary"
-  assert_output --regexp "Push operations: 5"
+  assert_output --partial "[test-results] Artifacts pushed: 5 operations"
 }
 
 @test "test-results gen-pipeline-report shows transfer summary" {
@@ -120,7 +117,7 @@ teardown() {
   run test-results gen-pipeline-report
   assert_success
   
-  assert_output --partial "test-results: Artifact Transfer Summary"
-  assert_output --regexp "(Pull|Push) operations:"
-  assert_output --partial "Total:"
+  assert_output --partial "[test-results] Artifact transfers:"
+  assert_output --regexp "(Pulled|Pushed):"
+  assert_output --partial "= Total:"
 }


### PR DESCRIPTION
We introduced a file operation summary for push/pull commands in the artifact CLI. However, the test results CLI hides the output of the artifact CLI operations. To fix this, test-results will read output of the artifact operations and create a summary in the following form:

```
* [test-results] Artifact transfers:
*   → Pulled: 1 operation, 43 files, 62.8 KB
*   ← Pushed: 2 operations, 2 files, 24.1 KB
*   = Total: 3 operations, 45 files, 86.9 KB
```