### PR TITLE
feat(test-results): add --no-trim-output flag and allow 0 to disable trimming

### DIFF
--- a/test-results/DOCUMENTATION.md
+++ b/test-results/DOCUMENTATION.md
@@ -43,7 +43,7 @@
 ## Configuration & Environment
 - Viper auto-loads `$HOME/.test-results.yaml` when present; command flags override config.
 - Key env vars: `SEMAPHORE_PIPELINE_ID`, `SEMAPHORE_WORKFLOW_ID`, `SEMAPHORE_JOB_ID`, `SEMAPHORE_AGENT_MACHINE_TYPE`, etc.; parsers read them to enrich metadata.
-- Flags to know: `--parser`, `--ignore-missing`, `--no-compress`, `--suite-prefix`, `--omit-output-for-passed`, `--trim-output-to`, `--name`.
+- Flags to know: `--parser`, `--ignore-missing`, `--no-compress`, `--suite-prefix`, `--omit-output-for-passed`, `--trim-output-to`, `--no-trim-output`, `--name`.
 
 ## Development Workflow
 - Requires Go 1.24+. Use `make test.setup` once to build the `cli` Docker image and fetch module deps.

--- a/test-results/README.md
+++ b/test-results/README.md
@@ -75,6 +75,21 @@ The generated tests in a report will sometimes contain a prefix in the name. For
 test-results publish --suite-prefix "Elixir." results.xml
 ```
 
+## Trimming test output
+
+By default, the CLI trims stdout/stderr fields to the last 1000 characters and prepends `...[truncated]...` when trimming occurs. You can change the limit or disable trimming entirely:
+
+```bash
+# Keep the last 5000 characters
+test-results publish --trim-output-to 5000 results.xml
+
+# Disable trimming
+test-results publish --no-trim-output results.xml
+
+# Also disables trimming
+test-results publish --trim-output-to 0 results.xml
+```
+
 ## Multiple reports from one job
 
 If your job generates multiple reports: `integration.xml`, `unit.xml` you can use this command to merge and publish them

--- a/test-results/cmd/root.go
+++ b/test-results/cmd/root.go
@@ -44,7 +44,8 @@ func init() {
 	rootCmd.PersistentFlags().StringP("suite-prefix", "S", "", "prefix for each suite")
 	rootCmd.PersistentFlags().StringP("parser", "p", "auto", "override parser to be used")
 	rootCmd.PersistentFlags().Bool("no-compress", false, "skip gzip compression for the output")
-	rootCmd.PersistentFlags().IntP("trim-output-to", "s", 1000, "trim stdout/stderr to last N characters (max 10000), defaults to 1000")
+	rootCmd.PersistentFlags().IntP("trim-output-to", "s", 1000, "trim stdout/stderr to last N characters, defaults to 1000 (use 0 or --no-trim-output to disable)")
+	rootCmd.PersistentFlags().Bool("no-trim-output", false, "disable output trimming entirely")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.

--- a/test-results/pkg/cli/cli.go
+++ b/test-results/pkg/cli/cli.go
@@ -466,16 +466,22 @@ func ApplyOutputTrimming(result *parser.Result, cmd *cobra.Command) {
 		return
 	}
 
+	// Check if trimming is disabled via --no-trim-output flag
+	noTrim, err := cmd.Flags().GetBool("no-trim-output")
+	if err == nil && noTrim {
+		return
+	}
+
 	trimTo := 1000
-	maxTrimLength := 10000
 
 	trimToFlag, err := cmd.Flags().GetInt("trim-output-to")
 	if err == nil {
 		trimTo = trimToFlag
 	}
 
-	if trimTo > maxTrimLength || trimTo <= 0 {
-		trimTo = maxTrimLength
+	// If trimTo is 0 or negative, disable trimming
+	if trimTo <= 0 {
+		return
 	}
 
 	for i := range result.TestResults {


### PR DESCRIPTION
Adds a CLI flag to disable test log trimming and clarifies trimming behavior in docs, allowing users to preserve full stdout/stderr when desired.

More details in [the task](https://github.com/renderedtext/tasks/issues/9066).