### PR TITLE
Make `cache` use `zstd` compression

### DIFF
--- a/cache-cli/Dockerfile.dev
+++ b/cache-cli/Dockerfile.dev
@@ -1,5 +1,7 @@
 FROM golang:1.23
 
+RUN apt-get update && apt-get install -y zstd && apt-get clean
+
 RUN go install gotest.tools/gotestsum@v1.12.3
 RUN mkdir /root/.ssh
 COPY id_rsa /root/.ssh/semaphore_cache_key

--- a/cache-cli/go.mod
+++ b/cache-cli/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.7.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/klauspost/compress v1.15.13 // indirect
+	github.com/klauspost/compress v1.18.3 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/cache-cli/go.sum
+++ b/cache-cli/go.sum
@@ -103,6 +103,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/klauspost/compress v1.15.13 h1:NFn1Wr8cfnenSJSA46lLq4wHCcBzKTSjnBIexDMMOV0=
 github.com/klauspost/compress v1.15.13/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
+github.com/klauspost/compress v1.18.3 h1:9PJRvfbmTabkOX8moIpXPbMMbYN60bWImDDU7L+/6zw=
+github.com/klauspost/compress v1.18.3/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU=
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=


### PR DESCRIPTION
Update the `cache` command to create Zstd-compressed archives rather than gzip-compressed. In testing, this reduces archive size by 20%, with proportional gains in download times, as well as a 50% reduction in decompression time.

This change is backwards-compatible and can handle existing, gzip-compressed archives without changes. To do this, we attempt to see if the file is valid Zstd. For the shell-out archiver, I opted to let `tar`'s built-in autodetection handle the differentiation. This works on all tested systems.

Tested manually on Semaphore Linux- and MacOS cloud runners. Timing improvements measured on our own hardware as Semaphore runners appear to be I/O bound.

Fixes #523. In the future, you might want to delete the old gzip implementation as it's messy.