### PR TITLE
fix: bump artifact cli version to v0.6.8

### DIFF
--- a/cache-cli/pkg/metrics/context.go
+++ b/cache-cli/pkg/metrics/context.go
@@ -1,3 +1,4 @@
+//revive:disable-next-line:var-naming
 package metrics
 
 import (

--- a/cache-cli/pkg/metrics/local.go
+++ b/cache-cli/pkg/metrics/local.go
@@ -1,3 +1,4 @@
+//revive:disable-next-line:var-naming
 package metrics
 
 import (

--- a/cache-cli/pkg/metrics/local_test.go
+++ b/cache-cli/pkg/metrics/local_test.go
@@ -1,3 +1,4 @@
+//revive:disable-next-line:var-naming
 package metrics
 
 import (

--- a/cache-cli/pkg/metrics/metrics.go
+++ b/cache-cli/pkg/metrics/metrics.go
@@ -1,3 +1,4 @@
+//revive:disable-next-line:var-naming
 package metrics
 
 import (

--- a/cache-cli/pkg/metrics/no_op.go
+++ b/cache-cli/pkg/metrics/no_op.go
@@ -1,3 +1,4 @@
+//revive:disable-next-line:var-naming
 package metrics
 
 type NoOpMetricsManager struct {

--- a/release/create.sh
+++ b/release/create.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-ARTIFACT_CLI_VERSION="v0.6.7"
+ARTIFACT_CLI_VERSION="v0.6.8"
 SPC_CLI_VERSION="v1.12.3"
 WHEN_CLI_VERSION="v1.4.0"
 # we include multiple when binaries for all supported Erlang versions


### PR DESCRIPTION
[Artifact CLI v0.6.8 was released](https://github.com/semaphoreci/artifact/releases/tag/v0.6.8) to fix [the path decoding issue](https://github.com/renderedtext/tasks/issues/9241).