### PR TITLE
feat(checkout): optional blobless partial clone + sparse working tree

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -370,8 +370,11 @@ blocks:
         commands:
           - checkout
 #          - brew untap homebrew/homebrew-cask-versions --force
-          - brew update
-          - brew upgrade ruby-build
+          # NONINTERACTIVE avoids the Homebrew upgrade confirmation prompt (which
+          # aborts with no TTY); `|| true` keeps a transient brew hiccup from
+          # failing the whole block before the tests run.
+          - NONINTERACTIVE=1 brew update || true
+          - NONINTERACTIVE=1 brew upgrade ruby-build || true
           - artifact pull workflow bin/linux/amd64/cache -d cache-cli/bin/linux/amd64/cache
           - artifact pull workflow bin/linux/arm64/cache -d cache-cli/bin/linux/arm64/cache
           - artifact pull workflow bin/darwin/amd64/cache -d cache-cli/bin/darwin/amd64/cache

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -370,11 +370,12 @@ blocks:
         commands:
           - checkout
 #          - brew untap homebrew/homebrew-cask-versions --force
-          # NONINTERACTIVE avoids the Homebrew upgrade confirmation prompt (which
-          # aborts with no TTY); `|| true` keeps a transient brew hiccup from
-          # failing the whole block before the tests run.
-          - NONINTERACTIVE=1 brew update || true
-          - NONINTERACTIVE=1 brew upgrade ruby-build || true
+          # Newer Homebrew prompts "Do you want to proceed? [y/n]" on upgrade and,
+          # with no TTY, blocks on stdin until the job is killed. Pipe `yes` to
+          # answer the prompt so brew proceeds without hanging; `|| true` keeps a
+          # transient brew failure from breaking the block before the tests run.
+          - brew update || true
+          - yes | brew upgrade ruby-build || true
           - artifact pull workflow bin/linux/amd64/cache -d cache-cli/bin/linux/amd64/cache
           - artifact pull workflow bin/linux/arm64/cache -d cache-cli/bin/linux/arm64/cache
           - artifact pull workflow bin/darwin/amd64/cache -d cache-cli/bin/darwin/amd64/cache

--- a/libcheckout
+++ b/libcheckout
@@ -11,7 +11,9 @@ function checkout() {
     echo "[Experimental stability] Using cached Git repository."
     checkout::use_cache
   else
-    if [ -n "${SEMAPHORE_GIT_REF_TYPE:-}" ]; then
+    if [ -n "${SEMAPHORE_GIT_PARTIAL_CLONE_FILTER:-}" ] || [ -n "${SEMAPHORE_GIT_SPARSE_CHECKOUT_PATHS:-}" ]; then
+      checkout::optimized
+    elif [ -n "${SEMAPHORE_GIT_REF_TYPE:-}" ]; then
       checkout::refbased
     else
       checkout::shallow
@@ -265,6 +267,109 @@ function checkout::refbased() {
   checkout::shallow
 }
 
+# === Optimized checkout: partial (blobless) clone + sparse working tree ===
+# Opt-in via env vars, used for example by the pipeline initialization job
+# where only the pipeline YAML and the Git history (trees/commits) are needed,
+# not the full working tree:
+#   SEMAPHORE_GIT_PARTIAL_CLONE_FILTER  e.g. "blob:none" -> git clone --filter=...
+#   SEMAPHORE_GIT_SPARSE_CHECKOUT_PATHS e.g. ".semaphore" -> cone-mode sparse-checkout
+# Either variable enables this path; whichever is set is applied.
+function checkout::configure_sparse() {
+  if [ -n "${SEMAPHORE_GIT_SPARSE_CHECKOUT_PATHS:-}" ]; then
+    echo "Configuring sparse-checkout for paths: ${SEMAPHORE_GIT_SPARSE_CHECKOUT_PATHS}"
+    git sparse-checkout init --cone
+    # Word-splitting is intentional: multiple space-separated paths are passed
+    # as separate arguments to `git sparse-checkout set`.
+    # shellcheck disable=SC2086
+    git sparse-checkout set ${SEMAPHORE_GIT_SPARSE_CHECKOUT_PATHS}
+  fi
+}
+
+function checkout::optimized() {
+  if [ -z "${SEMAPHORE_GIT_DEPTH:-""}" ]; then
+    SEMAPHORE_GIT_DEPTH=50
+  fi
+
+  local filter_args=()
+  if [ -n "${SEMAPHORE_GIT_PARTIAL_CLONE_FILTER:-}" ]; then
+    filter_args+=("--filter=${SEMAPHORE_GIT_PARTIAL_CLONE_FILTER}")
+  fi
+
+  echo "Performing optimized clone (filter: '${SEMAPHORE_GIT_PARTIAL_CLONE_FILTER:-none}', sparse-paths: '${SEMAPHORE_GIT_SPARSE_CHECKOUT_PATHS:-none}', depth: ${SEMAPHORE_GIT_DEPTH})"
+
+  local ref_type="${SEMAPHORE_GIT_REF_TYPE:-""}"
+
+  if [ "$ref_type" = "pull-request" ]; then
+    if ! checkout::git_clone "${filter_args[@]}" --no-checkout --depth "${SEMAPHORE_GIT_DEPTH}" "${SEMAPHORE_GIT_URL}" "${SEMAPHORE_GIT_DIR}"; then
+      echo "Revision: ${SEMAPHORE_GIT_SHA} not found .... Exiting"
+      return 1
+    fi
+    cd "${SEMAPHORE_GIT_DIR}" || exit
+    checkout::configure_sparse
+
+    # Try fetching the PR ref with a depth, fallback to no depth.
+    if retry git fetch "${filter_args[@]}" --depth "${SEMAPHORE_GIT_DEPTH}" origin +"${SEMAPHORE_GIT_REF}": 2>/dev/null ||
+      retry git fetch "${filter_args[@]}" origin +"${SEMAPHORE_GIT_REF}": 2>/dev/null; then
+      git checkout -qf FETCH_HEAD
+      echo "HEAD is now at ${SEMAPHORE_GIT_SHA}"
+      checkout::metric "$(du -s . | awk '{ print $1 }')"
+      return 0
+    fi
+
+    echo "Revision: ${SEMAPHORE_GIT_SHA} not found .... Exiting"
+    return 1
+  fi
+
+  if [ "$ref_type" = "tag" ]; then
+    if ! checkout::git_clone "${filter_args[@]}" --no-checkout --depth "${SEMAPHORE_GIT_DEPTH}" -b "${SEMAPHORE_GIT_TAG_NAME}" "${SEMAPHORE_GIT_URL}" "${SEMAPHORE_GIT_DIR}"; then
+      echo "Release $SEMAPHORE_GIT_TAG_NAME not found .... Exiting"
+      return 1
+    fi
+    cd "${SEMAPHORE_GIT_DIR}" || exit
+    checkout::configure_sparse
+    git checkout -qf "${SEMAPHORE_GIT_TAG_NAME}"
+    echo "HEAD is now at ${SEMAPHORE_GIT_SHA} Release ${SEMAPHORE_GIT_TAG_NAME}"
+    checkout::metric "$(du -s . | awk '{ print $1 }')"
+    return 0
+  fi
+
+  # push / branch / noRef
+  if ! checkout::git_clone "${filter_args[@]}" --no-checkout --depth "${SEMAPHORE_GIT_DEPTH}" -b "${SEMAPHORE_GIT_BRANCH}" "${SEMAPHORE_GIT_URL}" "${SEMAPHORE_GIT_DIR}"; then
+    echo "Branch not found performing full clone"
+    checkout::git_clone "${filter_args[@]}" --no-checkout "${SEMAPHORE_GIT_URL}" "${SEMAPHORE_GIT_DIR}"
+    cd "$SEMAPHORE_GIT_DIR" || exit
+    checkout::configure_sparse
+
+    if ! checkout::branch_checkout; then
+      return 1
+    fi
+
+    if checkout::checkrevision; then
+      git reset --hard "${SEMAPHORE_GIT_SHA}" 2>/dev/null
+    else
+      return 1
+    fi
+  else
+    cd "${SEMAPHORE_GIT_DIR}" || exit
+    checkout::configure_sparse
+
+    # With --no-checkout the working tree is empty; reset --hard materializes
+    # only the sparse paths at the requested SHA.
+    if ! git reset --hard "${SEMAPHORE_GIT_SHA}" 2>/dev/null; then
+      echo "SHA: $SEMAPHORE_GIT_SHA not found performing full clone"
+      retry git fetch "${filter_args[@]}" --unshallow
+
+      if checkout::checkrevision; then
+        git reset --hard "${SEMAPHORE_GIT_SHA}" 2>/dev/null
+      else
+        return 1
+      fi
+    fi
+  fi
+
+  checkout::metric "$(du -s . | awk '{ print $1 }')"
+}
+
 function checkout::metric() {
   if [[ "${SEMAPHORE_TOOLBOX_METRICS_ENABLED:-''}" == "true" ]]; then
     ref_type=${SEMAPHORE_GIT_REF_TYPE:-""}
@@ -466,6 +571,8 @@ function checkout::clone_with_alt_ip() {
 }
 
 export -f checkout
+export -f checkout::optimized
+export -f checkout::configure_sparse
 export -f checkout::git_clone
 export -f checkout::resilient_clone
 export -f checkout::clone_with_speed_check

--- a/libcheckout
+++ b/libcheckout
@@ -285,7 +285,26 @@ function checkout::configure_sparse() {
   fi
 }
 
+# The optimized checkout relies on `git sparse-checkout` (cone mode), which
+# requires git >= 2.25. On older clients the subcommand is unavailable.
+function checkout::supports_optimized() {
+  ! git sparse-checkout -h 2>&1 | grep -q "is not a git command"
+}
+
 function checkout::optimized() {
+  # Fall back to a standard checkout when the git client is too old to support
+  # sparse-checkout, so the requested optimization degrades gracefully into a
+  # correct (if non-optimized) clone instead of a broken/full one.
+  if ! checkout::supports_optimized; then
+    echo "Optimized checkout requested, but this git does not support 'sparse-checkout'; falling back to a standard checkout."
+    if [ -n "${SEMAPHORE_GIT_REF_TYPE:-}" ]; then
+      checkout::refbased
+    else
+      checkout::shallow
+    fi
+    return $?
+  fi
+
   if [ -z "${SEMAPHORE_GIT_DEPTH:-""}" ]; then
     SEMAPHORE_GIT_DEPTH=50
   fi
@@ -573,6 +592,7 @@ function checkout::clone_with_alt_ip() {
 export -f checkout
 export -f checkout::optimized
 export -f checkout::configure_sparse
+export -f checkout::supports_optimized
 export -f checkout::git_clone
 export -f checkout::resilient_clone
 export -f checkout::clone_with_speed_check

--- a/tests/libcheckout.bats
+++ b/tests/libcheckout.bats
@@ -3,6 +3,13 @@
 load "support/bats-support/load"
 load "support/bats-assert/load"
 
+# The optimized checkout uses `git sparse-checkout` (cone mode), available in
+# git >= 2.25. On older clients (e.g. the minimal Alpine image) it is missing
+# and checkout falls back to a standard full checkout.
+sparse_supported() {
+  ! git sparse-checkout -h 2>&1 | grep -q "is not a git command"
+}
+
 setup() {
 
   unset SEMAPHORE_GIT_REF_TYPE
@@ -314,17 +321,22 @@ teardown() {
 
   run checkout
   assert_success
-  assert_output --partial "Performing optimized clone"
-  assert_output --partial "Configuring sparse-checkout for paths: lib"
   assert_output --partial "HEAD is now at 91940c2"
-
-  # sparse path is materialized, paths outside it are not
   assert [ -d "$SEMAPHORE_GIT_DIR/lib" ]
-  assert [ ! -d "$SEMAPHORE_GIT_DIR/test" ]
 
-  # repository was cloned as a partial (promisor) clone
-  run git -C "$SEMAPHORE_GIT_DIR" config --get remote.origin.promisor
-  assert_output "true"
+  if sparse_supported; then
+    assert_output --partial "Performing optimized clone"
+    assert_output --partial "Configuring sparse-checkout for paths: lib"
+    # sparse path is materialized, paths outside it are not
+    assert [ ! -d "$SEMAPHORE_GIT_DIR/test" ]
+    # repository was cloned as a partial (promisor) clone
+    run git -C "$SEMAPHORE_GIT_DIR" config --get remote.origin.promisor
+    assert_output "true"
+  else
+    # git too old for sparse-checkout: graceful fallback to a full checkout
+    assert_output --partial "falling back to a standard checkout"
+    assert [ -d "$SEMAPHORE_GIT_DIR/test" ]
+  fi
 }
 
 @test "libcheckout - [Optimized] blobless only, no sparse paths keeps full tree" {
@@ -334,10 +346,10 @@ teardown() {
 
   run checkout
   assert_success
-  assert_output --partial "Performing optimized clone"
-  refute_output --partial "Configuring sparse-checkout"
   assert_output --partial "HEAD is now at 91940c2"
+  refute_output --partial "Configuring sparse-checkout"
 
+  # no sparse paths -> full working tree, whether optimized or fallback
   assert [ -d "$SEMAPHORE_GIT_DIR/lib" ]
   assert [ -d "$SEMAPHORE_GIT_DIR/test" ]
 }
@@ -351,10 +363,16 @@ teardown() {
 
   run checkout
   assert_success
-  assert_output --partial "Performing optimized clone"
   assert_output --partial "HEAD is now at $SEMAPHORE_GIT_SHA Release $SEMAPHORE_GIT_TAG_NAME"
   assert [ -d "$SEMAPHORE_GIT_DIR/lib" ]
-  assert [ ! -d "$SEMAPHORE_GIT_DIR/test" ]
+
+  if sparse_supported; then
+    assert_output --partial "Performing optimized clone"
+    assert [ ! -d "$SEMAPHORE_GIT_DIR/test" ]
+  else
+    assert_output --partial "falling back to a standard checkout"
+    assert [ -d "$SEMAPHORE_GIT_DIR/test" ]
+  fi
 }
 
 @test "libcheckout - [Optimized] sparse checkout on PR" {
@@ -366,8 +384,14 @@ teardown() {
 
   run checkout
   assert_success
-  assert_output --partial "Performing optimized clone"
   assert_output --partial "HEAD is now at $SEMAPHORE_GIT_SHA"
   assert [ -d "$SEMAPHORE_GIT_DIR/lib" ]
-  assert [ ! -d "$SEMAPHORE_GIT_DIR/test" ]
+
+  if sparse_supported; then
+    assert_output --partial "Performing optimized clone"
+    assert [ ! -d "$SEMAPHORE_GIT_DIR/test" ]
+  else
+    assert_output --partial "falling back to a standard checkout"
+    assert [ -d "$SEMAPHORE_GIT_DIR/test" ]
+  fi
 }

--- a/tests/libcheckout.bats
+++ b/tests/libcheckout.bats
@@ -10,6 +10,8 @@ setup() {
   unset SEMAPHORE_GIT_PR_SLUG
   unset SEMAPHORE_GIT_PR_NAME
   unset SEMAPHORE_GIT_PR_NUMBER
+  unset SEMAPHORE_GIT_PARTIAL_CLONE_FILTER
+  unset SEMAPHORE_GIT_SPARSE_CHECKOUT_PATHS
 
   export SEMAPHORE_GIT_URL="https://github.com/mojombo/grit.git"
   export SEMAPHORE_GIT_BRANCH=master
@@ -300,4 +302,72 @@ teardown() {
   run cat /tmp/toolbox_metrics
   assert_failure
   assert_line "cat: /tmp/toolbox_metrics: No such file or directory"
+}
+
+# Optimized checkout: partial (blobless) clone + sparse working tree
+
+@test "libcheckout - [Optimized] blobless + sparse checkout (push)" {
+  export SEMAPHORE_GIT_REF_TYPE="push"
+  export SEMAPHORE_GIT_SHA=91940c2cc18ec08b751482f806f1b8bfa03d98a5
+  export SEMAPHORE_GIT_PARTIAL_CLONE_FILTER="blob:none"
+  export SEMAPHORE_GIT_SPARSE_CHECKOUT_PATHS="lib"
+
+  run checkout
+  assert_success
+  assert_output --partial "Performing optimized clone"
+  assert_output --partial "Configuring sparse-checkout for paths: lib"
+  assert_output --partial "HEAD is now at 91940c2"
+
+  # sparse path is materialized, paths outside it are not
+  assert [ -d "$SEMAPHORE_GIT_DIR/lib" ]
+  assert [ ! -d "$SEMAPHORE_GIT_DIR/test" ]
+
+  # repository was cloned as a partial (promisor) clone
+  run git -C "$SEMAPHORE_GIT_DIR" config --get remote.origin.promisor
+  assert_output "true"
+}
+
+@test "libcheckout - [Optimized] blobless only, no sparse paths keeps full tree" {
+  export SEMAPHORE_GIT_REF_TYPE="push"
+  export SEMAPHORE_GIT_SHA=91940c2cc18ec08b751482f806f1b8bfa03d98a5
+  export SEMAPHORE_GIT_PARTIAL_CLONE_FILTER="blob:none"
+
+  run checkout
+  assert_success
+  assert_output --partial "Performing optimized clone"
+  refute_output --partial "Configuring sparse-checkout"
+  assert_output --partial "HEAD is now at 91940c2"
+
+  assert [ -d "$SEMAPHORE_GIT_DIR/lib" ]
+  assert [ -d "$SEMAPHORE_GIT_DIR/test" ]
+}
+
+@test "libcheckout - [Optimized] sparse checkout on tag" {
+  export SEMAPHORE_GIT_REF_TYPE="tag"
+  export SEMAPHORE_GIT_TAG_NAME='v2.4.1'
+  export SEMAPHORE_GIT_SHA=91940c2cc18ec08b751482f806f1b8bfa03d98a5
+  export SEMAPHORE_GIT_PARTIAL_CLONE_FILTER="blob:none"
+  export SEMAPHORE_GIT_SPARSE_CHECKOUT_PATHS="lib"
+
+  run checkout
+  assert_success
+  assert_output --partial "Performing optimized clone"
+  assert_output --partial "HEAD is now at $SEMAPHORE_GIT_SHA Release $SEMAPHORE_GIT_TAG_NAME"
+  assert [ -d "$SEMAPHORE_GIT_DIR/lib" ]
+  assert [ ! -d "$SEMAPHORE_GIT_DIR/test" ]
+}
+
+@test "libcheckout - [Optimized] sparse checkout on PR" {
+  export SEMAPHORE_GIT_REF_TYPE="pull-request"
+  export SEMAPHORE_GIT_REF="refs/pull/186/merge"
+  export SEMAPHORE_GIT_SHA=30774365e11f2b1e18706c9ed0920369f6d7c205
+  export SEMAPHORE_GIT_PARTIAL_CLONE_FILTER="blob:none"
+  export SEMAPHORE_GIT_SPARSE_CHECKOUT_PATHS="lib"
+
+  run checkout
+  assert_success
+  assert_output --partial "Performing optimized clone"
+  assert_output --partial "HEAD is now at $SEMAPHORE_GIT_SHA"
+  assert [ -d "$SEMAPHORE_GIT_DIR/lib" ]
+  assert [ ! -d "$SEMAPHORE_GIT_DIR/test" ]
 }


### PR DESCRIPTION
## What

Adds an opt-in "optimized" checkout path to the `checkout` toolbox command, for
callers that only need the Git history (commits/trees) and a subset of the
working tree rather than the full repository. It is controlled by two env vars
and is fully backwards compatible — when neither is set, `checkout` behaves
exactly as before.

```
SEMAPHORE_GIT_PARTIAL_CLONE_FILTER   e.g. "blob:none"  -> git clone --filter=...
SEMAPHORE_GIT_SPARSE_CHECKOUT_PATHS  e.g. ".semaphore" -> cone-mode sparse checkout
```

When either is set, `checkout` performs a `--no-checkout` (optionally filtered)
clone and a cone-mode sparse checkout limited to the requested paths, handling
push/branch, pull-request, and tag refs. For large repositories this avoids
downloading blob content and materializing tens of thousands of files when only
a small subset is needed.

## Changes

- `libcheckout`: new `checkout::optimized` / `checkout::configure_sparse` paths,
  dispatched from `checkout()` only when the new env vars are present. Existing
  `shallow` / `refbased` / `use-cache` paths are untouched.
- **Graceful fallback:** `git sparse-checkout` (cone mode) requires git >= 2.25.
  On older clients the optimized path detects the missing subcommand and falls
  back to a standard checkout, so the request degrades into a correct
  (non-optimized) clone instead of a full checkout from a blobless clone.
- `tests/libcheckout.bats`: capability-aware tests for push/branch, PR and tag —
  asserting the sparse working tree where supported and the full-tree fallback
  where not.
- CI: the macOS `xcode26 arm` block's prologue ran `brew upgrade ruby-build`,
  which newer Homebrew turns into an interactive `[y/n]` prompt that blocked on
  stdin and stopped the block (also broken on `master`). Pipe `yes` so it
  proceeds non-interactively.

## Testing

- bats `libcheckout` suite green on Docker, Linux, Ubuntu 24.04, and Alpine 3.9
  (git 2.20 -> exercises the fallback), plus `shellcheck -s bash libcheckout`.

> Pairs with a consumer change (a pipeline initialization job that sets these env
> vars) and a related compiler change; the env-var interface is additive and safe
> to merge independently.

## Related PRs

- https://github.com/semaphoreio/semaphore/pull/1063
- https://github.com/semaphoreci/spc/pull/59

🤖 Generated with [Claude Code](https://claude.com/claude-code)